### PR TITLE
Add GitHub Actions workflow for lightweight simulations

### DIFF
--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -1,0 +1,46 @@
+# path: .github/workflows/sims.yml
+name: simulations
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lightweight-headless:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run lightweight headless simulations
+        run: |
+          if [ -d simulations ]; then
+            echo "Running lightweight simulations under ./simulations"
+            pytest -q simulations --maxfail=1 || exit 1
+          else
+            echo "No ./simulations directory found; skipping headless run."
+          fi
+
+      - name: Document deferred heavy simulations
+        run: |
+          echo "TODO: Add GPU-accelerated / long-running simulation suite once dedicated runners are available."
+
+      - name: Upload figures artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: simulation-figures
+          path: figures
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- add a dedicated simulations workflow that prepares Python, installs requirements, and conditionally runs lightweight headless tasks under `./simulations`
- upload any generated figures as workflow artifacts and leave a TODO note for future heavy simulation coverage

## Testing
- not run (workflow definition only)


------
https://chatgpt.com/codex/tasks/task_e_68d73f078620832c952fdc0fe0931fdd