### PR TITLE
Document provenance scaffolding and consolidate deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ source .venv/bin/activate  # Linux/macOS
 
 # Install dependencies
 pip install --upgrade pip
-pip install -r experiments/requirements.txt
+pip install -r requirements.txt
 
 # Run the core demonstration
 python experiments/gp_ringing_demo.py
@@ -96,20 +96,19 @@ This project emphasizes reproducibility and falsifiability:
 
 ```
 Resonance_Geometry/
-├── experiments/
-│   ├── gp_ringing_demo.py       # Main demonstration script
-│   └── requirements.txt         # Python dependencies
 ├── docs/
-│   ├── codex/
-│   │   ├── policies/prereg_P1.md  # Pre-registration protocol
-│   │   └── policies/predictions.md
-│   ├── history/                  # Roadmap, import logs, etc.
-│   ├── philosophy/               # Conceptual framing
-│   └── white-papers/             # Drafts, appendices, compiled PDFs
+│   ├── philosophy/               # Conceptual framing and essays
+│   ├── white-papers/             # Drafts, appendices, compiled PDFs
+│   ├── codex/                    # Resonance codex variants & policies
+│   └── history/                  # Provenance logs, inventories, lineage
+├── simulations/                 # Simulation modules (headless)
 ├── figures/                     # Generated figures (tracked outputs)
-├── simulations/                 # Simulation modules
+├── archive/                     # Legacy repositories (REAL/GP/RG)
+├── experiments/
+│   └── gp_ringing_demo.py       # Main demonstration script
+├── scripts/                     # Utility helpers (inventory generation, etc.)
 ├── results/                     # Legacy outputs (gitignored)
-└── .github/workflows/           # CI configuration
+└── .github/workflows/           # CI configuration (sims.yml, etc.)
 ```
 
 -----
@@ -136,3 +135,21 @@ Please open an issue before submitting a pull request to coordinate efforts.
 ## License
 
 Apache 2.0 – see <LICENSE> for details.
+
+-----
+
+## Repository Lineage
+
+This canonical hub intentionally preserves the provenance of three legacy efforts:
+
+- [`REAL`](https://github.com/justindbilyeu/REAL)
+- [`Geometric-Plasticity-`](https://github.com/justindbilyeu/Geometric-Plasticity-)
+- [`ResonanceGeometry`](https://github.com/justindbilyeu/ResonanceGeometry)
+
+The `/archive/` directory houses frozen snapshots (or placeholders when network
+access is unavailable) for each source. Provenance, deduplication notes, and
+follow-up actions are tracked in [`docs/history/HISTORY.md`](docs/history/HISTORY.md).
+
+For a guided tour of the merged documentation set, start with
+[`docs/README_bundle.md`](docs/README_bundle.md) and the epistemic-status context
+in [`docs/Epistemic_Status_Box.md`](docs/Epistemic_Status_Box.md).

--- a/archive/Geometric-Plasticity-/IMPORT_NOTES.md
+++ b/archive/Geometric-Plasticity-/IMPORT_NOTES.md
@@ -1,3 +1,3 @@
 # Geometric-Plasticity- repository import status
 
-`git subtree add --prefix archive/Geometric-Plasticity- ...` could not reach the upstream repository because outbound HTTPS is blocked (CONNECT tunnel 403). The placeholder persists so the subtree can be added once connectivity is restored.
+`git subtree add --prefix archive/Geometric-Plasticity- ...` could not reach the upstream repository because outbound HTTPS is blocked (CONNECT tunnel 403). The placeholder persists so the subtree can be added once connectivity is restored. See [`docs/history/HISTORY.md`](../../docs/history/HISTORY.md) for provenance tracking and follow-up actions.

--- a/archive/REAL/IMPORT_NOTES.md
+++ b/archive/REAL/IMPORT_NOTES.md
@@ -1,3 +1,3 @@
 # REAL repository import status
 
-We attempted to import the upstream `REAL` repository history via `git subtree add --prefix archive/REAL ...`, but the sandboxed environment blocks outbound HTTPS connections (CONNECT tunnel 403). As a result, the upstream history could not be fetched automatically. The directory is reserved for a future subtree import once network access is available.
+We attempted to import the upstream `REAL` repository history via `git subtree add --prefix archive/REAL ...`, but the sandboxed environment blocks outbound HTTPS connections (CONNECT tunnel 403). As a result, the upstream history could not be fetched automatically. The directory is reserved for a future subtree import once network access is available. See [`docs/history/HISTORY.md`](../../docs/history/HISTORY.md) for provenance tracking and follow-up actions.

--- a/archive/ResonanceGeometry/IMPORT_NOTES.md
+++ b/archive/ResonanceGeometry/IMPORT_NOTES.md
@@ -1,3 +1,3 @@
 # ResonanceGeometry repository import status
 
-The `git subtree add --prefix archive/ResonanceGeometry ...` command failed because outbound network access to GitHub returned `CONNECT tunnel failed, response 403`. This directory is staged for a future subtree import when the network restriction is lifted.
+The `git subtree add --prefix archive/ResonanceGeometry ...` command failed because outbound network access to GitHub returned `CONNECT tunnel failed, response 403`. This directory is staged for a future subtree import when the network restriction is lifted. See [`docs/history/HISTORY.md`](../../docs/history/HISTORY.md) for provenance tracking and follow-up actions.

--- a/docs/Epistemic_Status_Box.md
+++ b/docs/Epistemic_Status_Box.md
@@ -1,0 +1,25 @@
+# Epistemic Status
+
+- **Confidence:** Medium-high for the core Geometric Plasticity predictions that
+  have reproducible simulations (`simulations/ringing_threshold.py`). Empirical
+  validation on biological datasets remains pending.
+- **Evidence Base:** Synthetic simulations and analytical derivations captured in
+  the white paper drafts. No peer-reviewed publications yet.
+- **Replication Plan:**
+  1. Re-run the lightweight simulations locally or via CI to verify deterministic
+     outputs in `figures/`.
+  2. Extend to EEG/MEG datasets following the preregistered analysis in
+     `docs/codex/policies/prereg_P1.md`.
+  3. Document any new datasets or parameter sweeps in `docs/history/HISTORY.md`.
+- **Update Cadence:** Quarterly for major theory revisions; continuous for minor
+  errata via pull requests.
+- **Open Questions:**
+  - How do hardware-accelerated estimators (ITPU) change the feasible parameter
+    sweep size?
+  - Can the REAL cosmological framing be reconciled with the GP formalism, or
+    should it remain archived legacy inspiration?
+  - What experimental protocols best distinguish GP predictions from alternative
+    network adaptation theories?
+
+Please duplicate this box (or link to it) in new documents that make strong
+claims so readers can quickly gauge maturity, validation status, and next steps.

--- a/docs/README_bundle.md
+++ b/docs/README_bundle.md
@@ -1,0 +1,58 @@
+# Resonance Geometry Documentation Bundle
+
+This bundle is organized so newcomers can navigate the merged Resonance Geometry
+materials without losing track of provenance or epistemic status. Use the
+sections below as a guided map.
+
+## 1. Philosophy (`docs/philosophy/`)
+- Conceptual framing, prefaces, and phenomenological essays.
+- Start with [`RG_GP_Preface.md`](philosophy/RG_GP_Preface.md) for a concise
+  description of why adaptive geometry matters.
+
+## 2. White Papers (`docs/white-papers/`)
+- Formal write-ups, appendices, and LaTeX sources for the Resonance Geometry and
+  Geometric Plasticity programs.
+- PDFs and LaTeX sources share filenames; variants or addenda are grouped in
+  subdirectories such as `draft/` and `appendices/`.
+
+## 3. Resonance Codex (`docs/codex/`)
+- Policies, predictions, experiment protocols, and hardware notes.
+- Highlights include [`policies/predictions.md`](codex/policies/predictions.md)
+  and the pre-registration dossier in
+  [`policies/prereg_P1.md`](codex/policies/prereg_P1.md).
+
+## 4. History & Provenance (`docs/history/`)
+- `HISTORY.md` tracks every imported artifact, its source repository, and
+  deduplication notes.
+- `archive_inventory.json` lists the current file layout to accelerate future
+  imports.
+- `import_log.md` records outstanding tasks (e.g., pending subtree pulls when
+  network access is restored).
+- Use `scripts/generate_inventory.py` to regenerate the JSON snapshot after
+  importing or reorganizing files.
+
+## 5. Simulations (`simulations/`)
+- Headless Python modules that reproduce the figures referenced in the docs.
+- CI executes the lightweight suite via `.github/workflows/sims.yml` and uploads
+  artifacts from `figures/`.
+
+## 6. Archive (`archive/`)
+- Preserves legacy repository trees (`REAL`, `Geometric-Plasticity-`,
+  `ResonanceGeometry`). When a full import is blocked (e.g., due to sandbox
+  networking limits) the folder contains an `IMPORT_NOTES.md` with the current
+  status and TODOs.
+
+## Epistemic Status
+- Review [`docs/Epistemic_Status_Box.md`](Epistemic_Status_Box.md) for the
+  project-wide confidence assessment, validation checkpoints, and replication
+  roadmap.
+
+## How to Contribute
+1. Read the Epistemic Status box to understand which claims are stable versus
+   exploratory.
+2. Use the provenance log to check whether your proposed changes supersede an
+   imported variant.
+3. Update `HISTORY.md` and the archive inventory whenever new legacy content is
+   added or deduplicated.
+4. Run the simulations workflow locally (`pytest simulations`) before opening a
+   PR so CI remains green.

--- a/docs/history/HISTORY.md
+++ b/docs/history/HISTORY.md
@@ -5,4 +5,7 @@ This log tracks legacy documentation and code snippets that have been imported f
 | File | Source Repo | Source Path | Commit (short) | Imported To | Notes |
 | --- | --- | --- | --- | --- | --- |
 | docs/itpu-sim/README.md | justindbilyeu/itpu-sim | README.md | n/a | docs/itpu-sim/README.md | Snapshot copied prior to establishing this log; original commit hash not recorded. |
+| archive/REAL/IMPORT_NOTES.md | justindbilyeu/REAL | IMPORT_NOTES.md (local placeholder) | n/a | archive/REAL/IMPORT_NOTES.md | Placeholder describing blocked subtree import because outbound HTTPS is restricted in the sandbox. |
+| archive/Geometric-Plasticity-/IMPORT_NOTES.md | justindbilyeu/Geometric-Plasticity- | IMPORT_NOTES.md (local placeholder) | n/a | archive/Geometric-Plasticity-/IMPORT_NOTES.md | Placeholder documenting pending import of the Geometric-Plasticity- history. |
+| archive/ResonanceGeometry/IMPORT_NOTES.md | justindbilyeu/ResonanceGeometry | IMPORT_NOTES.md (local placeholder) | n/a | archive/ResonanceGeometry/IMPORT_NOTES.md | Placeholder documenting pending import of the ResonanceGeometry legacy tree. |
 

--- a/docs/history/archive_inventory.json
+++ b/docs/history/archive_inventory.json
@@ -1,59 +1,57 @@
 {
-  "docs/white-papers": {
-    ".tex": [
-      "docs/white-papers/resonance_geometry_whitepaper.tex",
-      "docs/white-papers/resonance_geometry_integration.tex"
+  "docs": {
+    ".html": [
+      "docs/history/index.html"
+    ],
+    ".json": [
+      "docs/history/archive_inventory.json"
+    ],
+    ".md": [
+      "docs/Epistemic_Status_Box.md",
+      "docs/README_bundle.md",
+      "docs/codex/experiments/phase_surrogate.md",
+      "docs/codex/hardware/ITPU.md",
+      "docs/codex/itpu-sim/README.md",
+      "docs/codex/policies/predictions.md",
+      "docs/codex/policies/prereg_P1.md",
+      "docs/history/HISTORY.md",
+      "docs/history/ROADMAP.md",
+      "docs/history/import_log.md",
+      "docs/philosophy/RG_GP_Preface.md",
+      "docs/white-papers/appendices/appendix_ringing_threshold.md",
+      "docs/white-papers/draft/sections/00_preface.md"
     ],
     ".pdf": [
       "docs/white-papers/resonance_geometry_whitepaper.pdf"
     ],
-    ".md": [
-      "docs/white-papers/appendices/appendix_ringing_threshold.md",
-      "docs/white-papers/draft/sections/00_preface.md"
-    ]
-  },
-  "docs/codex": {
-    ".md": [
-      "docs/codex/policies/predictions.md",
-      "docs/codex/policies/prereg_P1.md",
-      "docs/codex/experiments/phase_surrogate.md",
-      "docs/codex/hardware/ITPU.md",
-      "docs/codex/itpu-sim/README.md"
-    ]
-  },
-  "docs/history": {
-    ".md": [
-      "docs/history/ROADMAP.md",
-      "docs/history/import_log.md"
+    ".tex": [
+      "docs/white-papers/resonance_geometry_integration.tex",
+      "docs/white-papers/resonance_geometry_whitepaper.tex"
     ],
-    ".html": [
-      "docs/history/index.html"
-    ]
-  },
-  "docs/philosophy": {
-    ".md": [
-      "docs/philosophy/RG_GP_Preface.md"
+    "<noext>": [
+      "docs/.nojekyll"
     ]
   },
   "simulations": {
     ".py": [
+      "simulations/__init__.py",
       "simulations/ringing_threshold.py"
     ]
   },
   "figures": {
-    ".gitkeep": [
+    "<noext>": [
       "figures/.gitkeep"
     ]
   },
   "archive": {
-    "REAL": {
-      ".md": [
-        "archive/REAL/IMPORT_NOTES.md"
-      ]
-    },
     "Geometric-Plasticity-": {
       ".md": [
         "archive/Geometric-Plasticity-/IMPORT_NOTES.md"
+      ]
+    },
+    "REAL": {
+      ".md": [
+        "archive/REAL/IMPORT_NOTES.md"
       ]
     },
     "ResonanceGeometry": {

--- a/docs/history/import_log.md
+++ b/docs/history/import_log.md
@@ -7,3 +7,21 @@ Attempts were made to import historical repositories using `git subtree add`:
 - `git subtree add --prefix archive/ResonanceGeometry <url> <branch>`
 
 Each command requires outbound HTTPS access to GitHub. The sandbox returned `CONNECT tunnel failed, response 403` (see shell log), so the upstream histories could not be fetched automatically. Placeholder directories with `IMPORT_NOTES.md` files were created to record the status and to make a future subtree add straightforward when network access is available.
+
+## Follow-up checklist once network access is restored
+
+1. Run the `git subtree add` commands above, targeting the default branch of each source repository.
+2. Regenerate [`docs/history/archive_inventory.json`](archive_inventory.json) using `python scripts/generate_inventory.py` (see below).
+3. Append per-file entries to [`HISTORY.md`](HISTORY.md) with commit hashes and import notes.
+4. Reconcile any filename conflicts by placing alternates under `docs/history/variants/` and noting the rationale.
+5. Update the README bundle and Epistemic Status box if new canonical documents are promoted.
+
+## Local helper script
+
+A small helper script (`scripts/generate_inventory.py`) can be run to rebuild the JSON inventory after imports:
+
+```bash
+python scripts/generate_inventory.py --output docs/history/archive_inventory.json
+```
+
+The script walks `docs/`, `simulations/`, `figures/`, and `archive/`, normalizes extensions, and produces a deterministic JSON map grouped by directory and filetype.

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -5,7 +5,7 @@ Run a minimal, prereg-aligned synthetic demo of P1/P2:
 ```bash
 python -m venv .venv && source .venv/bin/activate    # Windows: .\.venv\Scripts\Activate.ps1
 python -m pip install --upgrade pip
-pip install -r experiments/requirements.txt
+pip install -r requirements.txt
 python experiments/gp_ringing_demo.py
 Outputs:
 	•	figures/gp_demo/mi_timeseries.png

--- a/experiments/requirements.txt
+++ b/experiments/requirements.txt
@@ -1,3 +1,0 @@
-numpy>=1.22
-scipy>=1.9
-matplotlib>=3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# requirements.txt
+# Consolidated dependency list for experiments and simulations
 numpy>=1.23
 scipy>=1.10
 matplotlib>=3.7

--- a/scripts/generate_inventory.py
+++ b/scripts/generate_inventory.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Generate a JSON inventory of docs, simulations, figures, and archive contents."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_TARGETS = ["docs", "simulations", "figures", "archive"]
+
+
+def _scan_directory(directory: Path) -> Dict[str, List[str]]:
+    """Return a mapping of file suffix -> sorted list of relative paths."""
+    results: Dict[str, List[str]] = defaultdict(list)
+    for path in directory.rglob("*"):
+        if not path.is_file():
+            continue
+        suffix = path.suffix or "<noext>"
+        rel_path = path.relative_to(ROOT).as_posix()
+        results[suffix].append(rel_path)
+    return {suffix: sorted(paths) for suffix, paths in sorted(results.items())}
+
+
+def build_inventory() -> Dict[str, object]:
+    inventory: Dict[str, object] = {}
+    for name in DEFAULT_TARGETS:
+        directory = ROOT / name
+        if not directory.exists():
+            continue
+        if name == "archive":
+            per_repo: Dict[str, Dict[str, List[str]]] = {}
+            for repo_dir in sorted(directory.iterdir()):
+                if not repo_dir.is_dir():
+                    continue
+                per_repo[repo_dir.name] = _scan_directory(repo_dir)
+            inventory[name] = per_repo
+        else:
+            inventory[name] = _scan_directory(directory)
+    return inventory
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the JSON inventory. Prints to stdout when omitted.",
+    )
+    parser.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="Number of spaces to use for JSON indentation (default: 2).",
+    )
+    args = parser.parse_args()
+
+    inventory = build_inventory()
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(inventory, indent=args.indent) + "\n", encoding="utf-8")
+    else:
+        print(json.dumps(inventory, indent=args.indent))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- update the README with a repository lineage section, consolidated dependency instructions, and an explicit layout map that points to the new documentation hub
- add a navigation bundle and epistemic status box, refresh the provenance log/import notes, and regenerate the archive inventory with a helper script
- remove the duplicate experiments requirements file in favor of the top-level list and document how to rebuild the inventory once network access allows subtree imports

## Testing
- pytest *(fails: pandas dependency cannot be downloaded in the sandboxed environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d73caf12c8832c951f13298f763471