### PR TITLE
Chore: scaffolding for axioms, sims, specs, team tracker

### DIFF
--- a/docs/TEAM_TASKS.md
+++ b/docs/TEAM_TASKS.md
@@ -1,0 +1,9 @@
+| Owner    | Task                                  | Path/Artifact                                      | Status  | Notes |
+|----------|----------------------------------------|----------------------------------------------------|---------|-------|
+| Claude   | Axiom 3 Review (Emotion = Curvature)   | docs/axiom_reviews/Axiom3_EmotionCurvature.md      | DONE    | adopt tags repo-wide |
+| Claude   | Axiom 4 Review (Collapse = Coherence)  | docs/axiom_reviews/Axiom4_CollapseCoherence.md     | IN PROG | add Phase 1 sim plan |
+| Grok     | Spin-foam optimization (quick win)     | sims/spin_foam_mc_optimized.py; docs/sims/Spin_Foam_Optim.md | READY | merge + benchmark figs |
+| Grok     | Resonance Mapper spec                  | docs/specs/Resonance_Mapper.md                     | TODO    | inputs/outputs/invariants |
+| Wolfram  | Microtubule threshold map              | docs/sims/Microtubule_Collapse_Map.md              | TODO    | heatmaps + boundary |
+| Wolfram  | Spin-foam curvature scan               | docs/sims/SpinFoam_Curvature_Scan.md               | TODO    | curvature vs size |
+| DeepSeek | Literature taxonomy (≤2024)            | docs/research/Lit_Taxonomy_Pre2024.md              | TODO    | taxonomy + anchors |

--- a/docs/axiom_reviews/README.md
+++ b/docs/axiom_reviews/README.md
@@ -1,0 +1,1 @@
+This directory gathers draft and finalized axiom review notes that contextualize the Resonance Geometry framework; for broader guidance on intent and scope, see the root-level [RG_PROMPT.md](../../RG_PROMPT.md).

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,1 @@
+Background research digests, literature matrices, and citation trails accumulate here to keep the Resonance Geometry program grounded; consult [RG_PROMPT.md](../../RG_PROMPT.md) for mission alignment.

--- a/docs/sims/README.md
+++ b/docs/sims/README.md
@@ -1,0 +1,1 @@
+Simulation design notes and outcome summaries land here to capture how Resonance Geometry hypotheses get exercised computationally; for full program context refer to [RG_PROMPT.md](../../RG_PROMPT.md).

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,1 @@
+This folder houses working specifications for tooling, experiments, and integrations that support Resonance Geometry objectives; to align on overarching principles review [RG_PROMPT.md](../../RG_PROMPT.md).

--- a/docs/team_inputs/README.md
+++ b/docs/team_inputs/README.md
@@ -1,0 +1,1 @@
+Team-sourced prompts, annotations, and working notes live here so collaborators can sync on Resonance Geometry developments; see [RG_PROMPT.md](../../RG_PROMPT.md) for shared framing.

--- a/figures/README.md
+++ b/figures/README.md
@@ -1,0 +1,1 @@
+Visual assets, plot exports, and diagram drafts for Resonance Geometry analyses are staged here; for narrative anchors revisit [RG_PROMPT.md](../RG_PROMPT.md).


### PR DESCRIPTION
## Summary
- add dedicated documentation subdirectories for axioms, simulations, specs, team inputs, research, and figures
- seed each new folder with a README stub that links collaborators back to RG_PROMPT.md
- publish TEAM_TASKS kanban tracker capturing current owners, artifacts, and status

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d853ae6b3c832c8996fca863e63160