### PR TITLE
Docs: adopt epistemic status tags + CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing to Resonance Geometry
+
+Resonance Geometry thrives when contributions stay coherent, testable, and well-tagged. Before opening a pull request, make sure your updates align with the following:
+
+- Apply an epistemic status tag from [docs/EPistemic_Status.md](docs/EPistemic_Status.md) at the top of major documents, notebooks, and PR descriptions.
+- Keep every generated figure or rendering in the `/figures` directory with clear filenames and provenance notes.
+- Ensure simulations and demos run headless by default; provide CLI flags for optional visualization.
+- Document new simulation methods or protocols in `docs/sims/` with reproducible steps and references.
+- Update `TEAM_TASKS.md` with ownership, blockers, and status whenever you finish or re-scope a task.
+
+## Start Here
+- Understand our system framing in [docs/PROJECT_PROMPT.md](docs/PROJECT_PROMPT.md).
+- Review epistemic tag definitions in [docs/EPistemic_Status.md](docs/EPistemic_Status.md).

--- a/RG_PROMPT.md
+++ b/RG_PROMPT.md
@@ -16,8 +16,11 @@ This repo is our living lab: philosophy → equations → simulations → instru
 - Every artifact must raise **Clarity**, **Coherence**, and **Buildability**.
 - Metaphors are labeled; math is testable; code is reproducible.
 
+## Axioms and Tags
+- Epistemic clarity begins with explicit tags: see `docs/EPistemic_Status.md` for definitions and usage.
+
 ## Read next
-- **Master System Prompt:** `docs/PROJECT_PROMPT.md`  
+- **Master System Prompt:** `docs/PROJECT_PROMPT.md`
 - **Genesis (felt origin):** `docs/philosophy/Genesis.md`  
 - **Creed (short form):** `PROJECT_CREED.txt`  
 - **How the repo is organized:** `docs/README_bundle.md`  

--- a/docs/EPistemic_Status.md
+++ b/docs/EPistemic_Status.md
@@ -1,0 +1,18 @@
+# Epistemic Status Tags
+
+Use these tags to communicate how confident we are in a claim or artifact. They should appear at the top of documents, pull requests, and major updates.
+
+## [Epistemic Status: MATHEMATICAL-METAPHOR]
+Translates rigorous math into narrative or visual language while staying anchored to derivations.
+Highlights intuitive bridges that guide collaborators toward formal models without claiming proof.
+Example: a diagram in `docs/philosophy/` explaining tensor harmonics via dance metaphors.
+
+## [Epistemic Status: TESTABLE-HYPOTHESIS]
+Specifies a measurable prediction that could be falsified with current or near-future experiments.
+Outlines required instruments, datasets, or simulations and the success criteria.
+Example: a protocol in `docs/sims/` for validating resonance phase-locking with recorded biosignals.
+
+## [Epistemic Status: SPECULATIVE-THEORY]
+Explores frontier ideas that stretch beyond present evidence but fit our conceptual scaffold.
+Marks invitations for critique, extension, or reframing before implementation efforts begin.
+Example: a roadmap in `docs/philosophy/` mapping consciousness states to novel resonance manifolds.


### PR DESCRIPTION
## Summary
- add a dedicated epistemic tagging standard with examples for key status markers
- introduce a contributor guide that codifies repository workflow expectations
- reference the epistemic tag framework from the root prompt to highlight the new practice

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8558532f8832c9c8bd617dcf0e0b1