### PR TITLE
Docs: add Resonance Mapper and Microtubule Map spec stubs

### DIFF
--- a/docs/TEAM_TASKS.md
+++ b/docs/TEAM_TASKS.md
@@ -1,0 +1,6 @@
+# Team Tasks
+
+| Document | Description | Status |
+| --- | --- | --- |
+| [docs/specs/Resonance_Mapper.md](specs/Resonance_Mapper.md) | Specification stub outlining objectives, data inputs, and methods for the Resonance Mapper. | TODO |
+| [docs/sims/Microtubule_Collapse_Map.md](sims/Microtubule_Collapse_Map.md) | Simulation stub covering collapse lifetime sweeps over (γ, F) and reporting deliverables. | TODO |

--- a/docs/sims/Microtubule_Collapse_Map.md
+++ b/docs/sims/Microtubule_Collapse_Map.md
@@ -1,0 +1,13 @@
+# Microtubule Collapse Map Simulation Stub
+
+## Methods
+- Parameter grid exploration for damping factor (γ) and external forcing (F)
+- Lifetime metric tracking collapse events
+- Threshold at 50 cycles for collapse classification
+
+## Deliverables
+- Heatmap of collapse lifetimes across (γ, F)
+- Boundary curve delineating the 50-cycle threshold
+
+## Epistemic Status
+- TESTABLE-HYPOTHESIS

--- a/docs/specs/Resonance_Mapper.md
+++ b/docs/specs/Resonance_Mapper.md
@@ -1,0 +1,31 @@
+# Resonance Mapper Specification Stub
+
+## Objective
+- Outline the system for mapping resonance structures across spin-foam, human resonance, and microtubule coherence outputs.
+
+## Inputs
+- Spin-foam outputs
+- human_resonance outputs
+- Microtubule coherence outputs
+
+## Invariants
+- Betti numbers
+- Persistence landscapes
+- Coherence metrics
+
+## Methods
+- Graph neural network (GNN) backbone
+- Topological data analysis (TDA) via `ripser` or `giotto-tda`
+- Training data generation
+
+## Interfaces
+- `tools/resonance_mapper.py`
+- Command-line interface (CLI)
+- Plot outputs saved in `/figures`
+
+## Acceptance
+- Plots generated for validation scenarios
+- Unit tests on synthetic datasets
+
+## Epistemic Status
+- TESTABLE-HYPOTHESIS


### PR DESCRIPTION
## Summary
- add a specification stub for the Resonance Mapper covering objectives, data inputs, methods, and acceptance criteria
- add a simulation stub for the Microtubule Collapse Map with methods, deliverables, and epistemic status
- record the new documentation tasks in the team task tracker with TODO status

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d856d83a58832cb26eb4f7248255b7