### PR TITLE
CI: add minimal smoke tests (CPU-only, fast)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+addopts = -ra
+testpaths = tests
+xfail_strict = true
+filterwarnings =
+    error::DeprecationWarning
+    error::FutureWarning

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -1,0 +1,33 @@
+"""Lightweight environment sanity checks for CI."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import numpy as np
+
+
+def test_python_version() -> None:
+    """Ensure we are running on a modern Python that supports the project."""
+
+    assert sys.version_info >= (3, 10)
+
+
+def test_numpy_rng_reproducible() -> None:
+    """Check that numpy's default RNG is available and deterministic."""
+
+    rng = np.random.default_rng(0)
+    sample = rng.integers(0, 100, size=4)
+    assert sample.tolist() == [85, 63, 51, 26]
+
+
+def test_core_modules_importable() -> None:
+    """The key modules should import without raising."""
+
+    for name in [
+        "spin_foam_mc_optimized",
+        "experiments.spin_foam_smoke",
+    ]:
+        module = importlib.import_module(name)
+        assert module is not None

--- a/tests/test_spin_foam_smoke.py
+++ b/tests/test_spin_foam_smoke.py
@@ -1,0 +1,53 @@
+"""Smoke tests for the optimized spin-foam Monte Carlo driver."""
+
+from __future__ import annotations
+
+import pytest
+
+from spin_foam_mc_optimized import optimized_spin_foam_mc
+
+
+@pytest.mark.parametrize(
+    "steps,size,runs,seed",
+    [
+        (200, 8, 2, 7),
+        (128, 4, 1, 0),
+    ],
+)
+def test_spin_foam_summary_shape(steps: int, size: int, runs: int, seed: int) -> None:
+    """The sampler should produce deterministic, well-formed summaries."""
+
+    summary = optimized_spin_foam_mc(steps=steps, size=size, runs=runs, seed=seed)
+
+    assert summary["steps"] == steps
+    assert summary["size"] == size
+    assert summary["runs"] == runs
+    assert len(summary["per_run"]) == runs
+    assert all(entry["run"] == idx for idx, entry in enumerate(summary["per_run"]))
+    assert all("mean_amplitude" in entry for entry in summary["per_run"])
+    assert all("mean_energy" in entry for entry in summary["per_run"])
+    assert all("acceptance" in entry for entry in summary["per_run"])
+
+
+@pytest.mark.parametrize(
+    "seed,expected",
+    [
+        (7, {
+            "mean_amplitude": 0.005615327393209304,
+            "mean_energy": 0.3924015469987234,
+            "acceptance": 0.1425,
+        }),
+        (0, {
+            "mean_amplitude": 0.01270063215400305,
+            "mean_energy": 0.4323862557531094,
+            "acceptance": 0.1625,
+        }),
+    ],
+)
+def test_spin_foam_summary_values(seed: int, expected: dict[str, float]) -> None:
+    """Validate a couple of deterministic summaries for regression coverage."""
+
+    summary = optimized_spin_foam_mc(steps=200, size=8, runs=2, seed=seed)
+
+    for key, value in expected.items():
+        assert summary[key] == pytest.approx(value, rel=1e-6)


### PR DESCRIPTION
## Summary
- add lightweight sanity checks to ensure numpy RNG and core modules import cleanly
- add deterministic smoke coverage for the optimized spin-foam Monte Carlo driver
- configure pytest defaults for the repository so CI runs with consistent options

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d86c2fa1e8832c96b6113c29a52ea9