### PR TITLE
Stabilize GP ringing demo and expand smoke coverage

### DIFF
--- a/docs/sims/gp_ringing_demo_stability_plan.md
+++ b/docs/sims/gp_ringing_demo_stability_plan.md
@@ -1,0 +1,26 @@
+# GP Ringing Demo Stability Repair Plan
+
+## Context
+
+Running `experiments/gp_ringing_demo.py` triggered overflows and NaNs inside the
+`simulate_coupled` oscillator. When `lam` approached its maximum coupling, the
+linear AR(2) recurrence became unstable, producing non-finite values that caused
+`numpy.histogram2d` to crash while estimating mutual information. The demo could
+not complete as a result.
+
+## Repair Actions
+
+1. **Stabilise the oscillator** – introduce a gentle saturation non-linearity in
+   `simulate_coupled` so the state variables remain finite even when the coupling
+   temporarily pushes the linear dynamics past their stability boundary.
+2. **Backfill tests** – cover both the CLI helper for the spin-foam smoke test
+   and the MI demo so the regression is detected automatically.
+3. **Regression check** – rerun the pytest suite and exercise the demo script to
+   confirm the outputs are generated without warnings or crashes.
+
+## Expected Outcomes
+
+- `python experiments/gp_ringing_demo.py` completes successfully and writes the
+  summary artefacts.
+- The new tests fail if either the CLI helpers or the synthetic oscillator
+  return non-finite data, providing guard rails for future edits.

--- a/experiments/gp_ringing_demo.py
+++ b/experiments/gp_ringing_demo.py
@@ -49,8 +49,15 @@ def simulate_coupled(fs=128, dur_up=60, dur_dn=60, lam_max=0.9, seed=7):
 
     for t in range(2, len(lam)):
         c = lam[t]
-        x[t] = a1*x[t-1] + a2*x[t-2] + c*y[t-1] + nx[t]
-        y[t] = a1*y[t-1] + a2*y[t-2] + c*x[t-1] + ny[t]
+        x_new = a1*x[t-1] + a2*x[t-2] + c*y[t-1] + nx[t]
+        y_new = a1*y[t-1] + a2*y[t-2] + c*x[t-1] + ny[t]
+
+        # Soft saturation guards against runaway amplification when the mutual
+        # coupling pushes the linear AR(2) dynamics past the stability region.
+        # This keeps the synthetic demo numerically well behaved without
+        # changing the qualitative ringing / hysteresis behaviour we visualise.
+        x[t] = np.tanh(x_new)
+        y[t] = np.tanh(y_new)
     return lam, x, y
 
 # ---------- Analysis ----------

--- a/tests/test_gp_ringing_demo.py
+++ b/tests/test_gp_ringing_demo.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import numpy as np
+
+from experiments.gp_ringing_demo import simulate_coupled, windowed_mi
+
+
+def test_simulate_coupled_stays_finite() -> None:
+    lam, x, y = simulate_coupled(fs=64, dur_up=5, dur_dn=5, lam_max=0.9, seed=1)
+
+    assert np.isfinite(lam).all()
+    assert np.isfinite(x).all()
+    assert np.isfinite(y).all()
+
+    starts, mi_vals = windowed_mi(x, y, win=128, hop=32, bins=16)
+    assert starts.size > 0
+    assert np.isfinite(mi_vals).all()

--- a/tests/test_spin_foam_smoke.py
+++ b/tests/test_spin_foam_smoke.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from experiments.spin_foam_smoke import format_summary, parse_args
 from spin_foam_mc_optimized import optimized_spin_foam_mc
 
 
@@ -51,3 +52,29 @@ def test_spin_foam_summary_values(seed: int, expected: dict[str, float]) -> None
 
     for key, value in expected.items():
         assert summary[key] == pytest.approx(value, rel=1e-6)
+
+
+def test_spin_foam_cli_helpers() -> None:
+    """CLI helpers should parse arguments and format summaries safely."""
+
+    args = parse_args(["--steps", "100", "--size", "6", "--runs", "3", "--seed", "5", "--json"])
+
+    assert args.steps == 100
+    assert args.size == 6
+    assert args.runs == 3
+    assert args.seed == 5
+    assert args.json is True
+
+    summary = {
+        "size": 6,
+        "steps": 100,
+        "runs": 3,
+        "mean_amplitude": 0.123456,
+        "mean_energy": 0.654321,
+        "acceptance": 0.42,
+    }
+
+    formatted = format_summary(summary)
+
+    assert "6x6" in formatted
+    assert "0.420" in formatted


### PR DESCRIPTION
## Summary
- prevent the synthetic oscillator in `simulate_coupled` from overflowing by adding a soft saturation step
- document the failure and remediation steps in a new stability repair plan
- extend the pytest suite with coverage for the ringing demo and the spin-foam CLI helpers

## Testing
- pytest
- python experiments/gp_ringing_demo.py


------
https://chatgpt.com/codex/tasks/task_e_68d86e097eb4832c85a20061fdbe4176