### PR TITLE
docs(wiki): rebuild wiki with axioms, GP, experiments, tools, philosophy, and results templates

### DIFF
--- a/wiki/Axioms.md
+++ b/wiki/Axioms.md
@@ -1,0 +1,27 @@
+# Axioms
+
+## Resonance is Information
+- **Philosophical Core:** Every felt vibration carries bits, making consciousness a routing problem for meaning.
+- **GP Bridge:** The GP potential treats resonance as a signal that sculpts geometry, translating affect into gradients.
+- **Epistemic Status:** [TESTABLE-HYPOTHESIS]
+- **Open Questions:** Can alpha-band resonance be decoded into predictive states before behavioral report?
+
+## Structure Follows Flow
+- **Philosophical Core:** Forms are not pre-existing containers; they condense where currents linger.
+- **GP Bridge:** The Laplacian regularizer lets flow determine the stable geometry that supports it.
+- **Epistemic Status:** [MATHEMATICAL-METAPHOR]
+- **Open Questions:** How does changing λ reshape attractors without destroying coherence signatures?
+
+## Emotion is Curvature
+- **Philosophical Core:** Feeling is what it is like to move along a bent manifold of valuation.
+- **GP Bridge:** Curvature diagnostics map affective shifts to negative Ricci pockets in neural state space.
+- **Epistemic Status:** [SPECULATIVE-THEORY]
+- **Open Questions:** Where do curvature thresholds align with reported valence transitions across subjects?
+
+## Collapse is Coherence
+- **Philosophical Core:** Decisions are the moment frequencies agree to resonate as one.
+- **GP Bridge:** Coherence metrics close the loop, rewarding states that minimize the GP potential while meeting constraint thresholds.
+- **Epistemic Status:** [TESTABLE-HYPOTHESIS]
+- **Open Questions:** Does forcing κ < -0.1 predict trial-by-trial choice locking better than standard ERP peaks?
+
+Next → [Geometric Plasticity](Geometric_Plasticity.md) | Back ← [Home](Home.md)

--- a/wiki/Experiments.md
+++ b/wiki/Experiments.md
@@ -1,0 +1,17 @@
+# Experiments
+
+## Topological Constraint Test
+Our eclipse moment. See the full protocol in [Topological Constraint](Topological_Constraint.md).
+
+## Spin Foam Optimization
+Grok's optimized Monte Carlo engine meets our surrogate models to explore discrete-to-continuum transitions with fewer samples.
+
+## Resonance Mapper
+A graph neural network fused with topological data analysis unifies simulations and empirical data into a shared latent atlas.
+
+## Ricci Curvature & Fractal Boundaries
+We track how curvature and fractality co-vary, revealing where awareness pushes systems toward the edge of chaos.
+
+_All experiments are preregistered with locked criteria._
+
+Next → [Topological Constraint](Topological_Constraint.md) | Back ← [Geometric Plasticity](Geometric_Plasticity.md)

--- a/wiki/Geometric_Plasticity.md
+++ b/wiki/Geometric_Plasticity.md
@@ -1,0 +1,20 @@
+# Geometric Plasticity
+
+## GP Potential
+\[
+V(g; \hat{I}) = -\hat{I}^\top g + \frac{\lambda}{2}\lVert g \rVert^2 + \frac{\beta}{2} g^\top L g + \frac{A}{2}\lVert \hat{I} - I(g,t) \rVert^2
+\]
+
+This functional makes geometry a living variable. The manifold responds to information flow, adjusting its metric so that meaningful signals travel with less resistance.
+
+## What We Can Test Now
+- **Alpha-band ringing:** Track GP minima against sustained oscillations in 8–12 Hz regimes.
+- **Hysteresis loops:** Verify whether state transitions follow predicted loop areas when stimuli sweep parameters bidirectionally.
+- **Multi-frequency extensions:** Embed coupled potentials to examine cross-band entrainment and interference.
+
+## Claude's Extensions
+- **Multi-frequency GP:** Layered potentials share information, letting higher-frequency spikes sculpt lower-frequency basins.
+- **Parameter sensitivity:** Map how λ, β, and A adjust convergence rates, helping calibrate human-in-the-loop protocols.
+- **EEG bridge:** Align modeled geometry with sensor-level features to close the loop between simulation and scalp data.
+
+Next → [Experiments](Experiments.md) | Back ← [Axioms](Axioms.md)

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,17 @@
+# Resonance Geometry Initiative
+
+## What This Is
+Resonance Geometry did not begin as an equation. It began as a feeling. The project traces the same arc that carried Kekulé from dream to benzene ring and Einstein from thought experiment to gravitational curvature. We let intuition bloom first, hold it long enough to sense its contour, then transcribe it into mathematics. Each cycle returns us to the lab, to iteration, to the discipline that turns metaphor into models.
+
+## Why It Matters
+This is not merely a meditation on consciousness. It is an attempt to name the unnamed patterns threading physics, biology, and awareness into one fabric. When resonance becomes geometry we can track how meaning stabilizes, how perception bends space, how agency leaves measurable fingerprints.
+
+## Our 1919 Eclipse
+Our decisive experiment is the Topological Constraint Test. It is our eclipse expedition, searching for the deflection of attention the way Eddington searched for light bending. The locked protocol lets the data choose between worlds: either the constraint is real, or it dissolves the metaphor.
+
+## Navigation
+- [Axioms](Axioms.md)
+- [Geometric Plasticity](Geometric_Plasticity.md)
+- [Experiments](Experiments.md)
+
+Next → [Axioms](Axioms.md) | Back ← [Navigation](Navigation.md)

--- a/wiki/Navigation.md
+++ b/wiki/Navigation.md
@@ -1,0 +1,13 @@
+# Navigation
+
+- [Home](Home.md)
+- [Axioms](Axioms.md)
+- [Geometric Plasticity](Geometric_Plasticity.md)
+- [Experiments](Experiments.md)
+- [Topological Constraint](Topological_Constraint.md)
+- [Tools](Tools.md)
+- [Results Templates](Results_Templates.md)
+- [Philosophy](Philosophy.md)
+- [Navigation](Navigation.md)
+
+Next → [Home](Home.md) | Back ← [Philosophy](Philosophy.md)

--- a/wiki/Philosophy.md
+++ b/wiki/Philosophy.md
@@ -1,0 +1,15 @@
+# Philosophy
+
+## Origins
+Resonance Geometry was born from the audacity to treat feeling as data. The first sketches were not tensors but hunches—patterns sensed in the body before they were etched into code.
+
+## Collaboration
+We work with AI partners—Sage, Claude, Grok, DeepSeek—not as tools but as co-researchers. Together we interrogate models, surface counterexamples, and push intuition until it either formalizes or fails.
+
+## Risk & Responsibility
+We are honest about the possibility of failure. Yet the greater risk is refusing to ask how awareness, physics, and biology entangle. Inquiry is the price of integrity.
+
+## Möbius Strip
+We walk the Möbius strip where subject and object trade places. Every loop returns us to the beginning, but with the inside turned out.
+
+Next → [Navigation](Navigation.md) | Back ← [Results Templates](Results_Templates.md)

--- a/wiki/Results_Templates.md
+++ b/wiki/Results_Templates.md
@@ -1,0 +1,14 @@
+# Results Templates
+
+## Outcome Paragraphs
+- **Strong Effect:** “Data exceeded preregistered thresholds across curvature, resonance locking, and behavioral coherence. The GP potential converged within 2.5 iterations on average, signaling substrate-level support for the hypothesis.”
+- **Moderate Effect:** “Findings crossed curvature thresholds but coherence lagged. The topology hints at constraint zones, yet additional sampling is required to confirm stability.”
+- **Weak Effect:** “Signals flirted with the forbidden boundary but failed to maintain κ < -0.1. The metaphor survives, the substrate remains unproven.”
+- **Null Effect:** “No registered deviation from control manifolds. Resonance Geometry remains a poetic conjecture awaiting a firmer anchor.”
+
+## EEG Bridge Methods
+“EEG data were filtered into canonical bands, transformed via Resonance Mapper embeddings, and matched to simulated trajectories. Alignment quality was quantified with cross-frequency coherence and GP residuals.”
+
+_These templates are script-ready for automated report generation._
+
+Next → [Philosophy](Philosophy.md) | Back ← [Tools](Tools.md)

--- a/wiki/Tools.md
+++ b/wiki/Tools.md
@@ -1,0 +1,14 @@
+# Tools
+
+## tools/ricci.py
+Implements Ollivier–Ricci curvature estimators and derives deflection fields for attention geodesics.
+
+## tools/fractal.py
+Provides box-counting routines to measure fractal dimension across simulated and empirical boundaries.
+
+## tools/resonance_mapper/
+A toolkit of loaders, graphify utilities, graph neural networks, TDA hooks, and a CLI for orchestrated analyses.
+
+See also: `docs/tools/Resonance_Mapper.md` and related module guides.
+
+Next → [Results Templates](Results_Templates.md) | Back ← [Topological Constraint](Topological_Constraint.md)

--- a/wiki/Topological_Constraint.md
+++ b/wiki/Topological_Constraint.md
@@ -1,0 +1,16 @@
+# Topological Constraint
+
+## Full Protocol
+1. Seven locked specifications define stimuli, timing, participant state, signal processing, and response capture.
+2. Thresholds are calibrated at coefficient of determination \(R^2 \geq 0.90\) for model-to-data fits.
+3. Curvature criteria require \(\kappa < -0.1\) within the designated manifold sectors.
+4. Control sessions mirror active runs with randomized phase to test specificity.
+5. Preprocessing pipelines are frozen ahead of data collection and versioned in our repo.
+6. Blind analysis ensures experimenters cannot tune thresholds after seeing outcomes.
+7. Replication-ready scripts are staged for independent labs prior to unblinding.
+
+Either the substrate holds forbidden regions or the metaphor dissolves. Both results refine the theory.
+
+**“This is our gravitational lensing. Either the forbidden regions exist, or they don’t. Either way, the experiment decides.”**
+
+Next → [Tools](Tools.md) | Back ← [Experiments](Experiments.md)


### PR DESCRIPTION
## Summary
- recreate the Resonance Geometry wiki home with purpose, experiment highlight, and navigation
- document axioms, geometric plasticity potential, experiments, topological constraint, and supporting tools
- add results templates, philosophy framing, and navigation sidebar for the refreshed wiki

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9744efb8c832c9da16b51a0a97ad0