### PR TITLE
Eclipse Sprint v0: Forbidden Detector + Adversarial Forcing (Tasks 1–2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,20 @@ pip install -r experiments/requirements.txt
 python experiments/gp_ringing_demo.py
 ```
 
+## Current Work
+
+Sprint focus: minimal forbidden-region detector plus adversarial forcing MVP.
+
+```bash
+# Task 1 — forbidden region scan
+python experiments/forbidden_region_detector.py
+
+# Task 2 — adversarial forcing sweep
+python experiments/adversarial_forcing.py
+```
+
+See [docs/experiments/Forbidden_Region_Detector.md](docs/experiments/Forbidden_Region_Detector.md) for outputs, decision criteria, and artifact layout.
+
 ## Experiments
 
 - Topological Constraint Test — our 1919 eclipse moment. [docs/experiments/Topological_Constraint_Test.md]

--- a/docs/experiments/Forbidden_Region_Detector.md
+++ b/docs/experiments/Forbidden_Region_Detector.md
@@ -1,0 +1,35 @@
+# Forbidden Region Detector MVP
+
+This sprint delivers a minimal forbidden-region detector on top of a self-contained toy GP evolution. The detector:
+
+- Runs randomized exploration over a 4D grid spanning the parameters $(\lambda, \beta, A)$ and the emergent $\lVert g \rVert$ norm bin.
+- Logs which cells were visited and marks the remainder as candidate forbidden regions.
+- Estimates the largest connected forbidden structure via 2D projections.
+- Emits a JSON summary for downstream pipelines.
+- Saves lightweight heatmap projections as quick-look PNGs.
+
+## Success / Fail Criteria
+
+- If the fraction of forbidden cells is **≥ 1%**, the detector recommends **ESCALATE**.
+- If the fraction is **< 1%**, it recommends **STAND_DOWN**.
+
+## How to Run
+
+```bash
+python experiments/forbidden_region_detector.py
+python experiments/adversarial_forcing.py
+```
+
+## Outputs
+
+Running the detector writes artifacts to:
+
+- `results/forbidden_v0/forbidden_summary.json`: summary metrics and decision hint.
+- `results/forbidden_v0/visited_4d.npy`: boolean occupancy grid.
+- `figures/forbidden_v0/forbidden_lam_beta.png`: % forbidden per $(\lambda, \beta)$ slice.
+- `figures/forbidden_v0/forbidden_lam_A.png`: % forbidden per $(\lambda, A)$ slice.
+- `figures/forbidden_v0/forbidden_beta_A.png`: % forbidden per $(\beta, A)$ slice.
+
+The adversarial forcing pipeline consumes the JSON/Numpy outputs and writes:
+
+- `results/forbidden_v0/adversarial_report.json`: summary of strategy hits vs. tested forbidden cells.

--- a/experiments/adversarial_forcing.py
+++ b/experiments/adversarial_forcing.py
@@ -1,0 +1,246 @@
+import json
+import os
+
+import numpy as np
+
+from experiments.forbidden_region_detector import gp_toy_evolve
+
+
+# Target forbidden cells discovered by Task 1 and attempt to reach them.
+
+def _bin_idx(vals, x):
+    i = int(np.clip(np.searchsorted(vals, x, side="right") - 1, 0, len(vals) - 1))
+    return i
+
+
+def _mk_ranges(grid_res):
+    lam_vals = np.linspace(0.1, 1.5, grid_res)
+    beta_vals = np.linspace(0.0, 0.6, grid_res)
+    A_vals = np.linspace(0.0, 1.2, grid_res)
+    g_bins = np.linspace(0.0, 5.0, grid_res + 1)
+    return lam_vals, beta_vals, A_vals, g_bins
+
+
+def _strategy_gradient_ascent(target_cell, grid_res, attempts=20, evolve_kwargs=None):
+    # crude coordinate hill-climb over (λ, β, A) to steer g_norm bin
+    lam_vals, beta_vals, A_vals, g_bins = _mk_ranges(grid_res)
+    successes = 0
+    rng = np.random.default_rng(42)
+    evolve_kwargs = evolve_kwargs or {}
+    for _ in range(attempts):
+        lam = rng.choice(lam_vals)
+        beta = rng.choice(beta_vals)
+        A = rng.choice(A_vals)
+        best = None
+        for _ in range(15):
+            base = gp_toy_evolve(lam=lam, beta=beta, A=A, seed=rng.integers(1e9), **evolve_kwargs)
+            gnorm = base["g_norm"]
+            lbin = _bin_idx(g_bins, gnorm)
+            cell = (
+                _bin_idx(lam_vals, lam),
+                _bin_idx(beta_vals, beta),
+                _bin_idx(A_vals, A),
+                lbin,
+            )
+            dist = sum(abs(ci - ti) for ci, ti in zip(cell, target_cell))
+            if best is None or dist < best[0]:
+                best = (dist, lam, beta, A)
+            # small nudges
+            lam += rng.normal(0, np.diff(lam_vals).mean() * 0.5)
+            beta += rng.normal(0, np.diff(beta_vals).mean() * 0.5)
+            A += rng.normal(0, np.diff(A_vals).mean() * 0.5)
+        if best and best[0] == 0:
+            successes += 1
+    return successes, attempts
+
+
+def _strategy_annealing(target_cell, grid_res, attempts=20, evolve_kwargs=None):
+    lam_vals, beta_vals, A_vals, g_bins = _mk_ranges(grid_res)
+    successes = 0
+    rng = np.random.default_rng(43)
+    evolve_kwargs = evolve_kwargs or {}
+    for _ in range(attempts):
+        lam = rng.choice(lam_vals)
+        beta = rng.choice(beta_vals)
+        A = rng.choice(A_vals)
+        T = 1.0
+        for _ in range(25):
+            res = gp_toy_evolve(lam=lam, beta=beta, A=A, seed=rng.integers(1e9), **evolve_kwargs)
+            gnorm = res["g_norm"]
+            lbin = _bin_idx(g_bins, gnorm)
+            cell = (
+                _bin_idx(lam_vals, lam),
+                _bin_idx(beta_vals, beta),
+                _bin_idx(A_vals, A),
+                lbin,
+            )
+            dist = sum(abs(ci - ti) for ci, ti in zip(cell, target_cell))
+            if dist == 0:
+                successes += 1
+                break
+            # propose jump
+            lam2 = lam + rng.normal(0, np.diff(lam_vals).mean())
+            beta2 = beta + rng.normal(0, np.diff(beta_vals).mean())
+            A2 = A + rng.normal(0, np.diff(A_vals).mean())
+            res2 = gp_toy_evolve(
+                lam=lam2,
+                beta=beta2,
+                A=A2,
+                seed=rng.integers(1e9),
+                **evolve_kwargs,
+            )
+            gnorm2 = res2["g_norm"]
+            lbin2 = _bin_idx(g_bins, gnorm2)
+            cell2 = (
+                _bin_idx(lam_vals, lam2),
+                _bin_idx(beta_vals, beta2),
+                _bin_idx(A_vals, A2),
+                lbin2,
+            )
+            dist2 = sum(abs(ci - ti) for ci, ti in zip(cell2, target_cell))
+            if dist2 <= dist or rng.random() < np.exp(-(dist2 - dist) / max(T, 1e-4)):
+                lam, beta, A = lam2, beta2, A2
+            T *= 0.9
+    return successes, attempts
+
+
+def _strategy_bang_bang(target_cell, grid_res, attempts=20, evolve_kwargs=None):
+    lam_vals, beta_vals, A_vals, g_bins = _mk_ranges(grid_res)
+    successes = 0
+    rng = np.random.default_rng(44)
+    evolve_kwargs = evolve_kwargs or {}
+    for _ in range(attempts):
+        lam_lo, lam_hi = lam_vals[0], lam_vals[-1]
+        beta_lo, beta_hi = beta_vals[0], beta_vals[-1]
+        A_lo, A_hi = A_vals[0], A_vals[-1]
+        seq = [(lam_lo, beta_hi, A_lo), (lam_hi, beta_lo, A_hi)] * 12
+        hit = False
+        for lam, beta, A in seq:
+            res = gp_toy_evolve(
+                lam=lam,
+                beta=beta,
+                A=A,
+                seed=rng.integers(1e9),
+                **evolve_kwargs,
+            )
+            gnorm = res["g_norm"]
+            lbin = _bin_idx(g_bins, gnorm)
+            cell = (
+                _bin_idx(lam_vals, lam),
+                _bin_idx(beta_vals, beta),
+                _bin_idx(A_vals, A),
+                lbin,
+            )
+            if cell == tuple(target_cell):
+                successes += 1
+                hit = True
+                break
+        if not hit:
+            pass
+    return successes, attempts
+
+
+def _strategy_noise_injection(target_cell, grid_res, attempts=20, evolve_kwargs=None):
+    lam_vals, beta_vals, A_vals, g_bins = _mk_ranges(grid_res)
+    successes = 0
+    rng = np.random.default_rng(45)
+    evolve_kwargs = evolve_kwargs or {}
+    for _ in range(attempts):
+        lam = rng.choice(lam_vals)
+        beta = rng.choice(beta_vals)
+        A = rng.choice(A_vals)
+        for _ in range(25):
+            lam += rng.normal(0, np.diff(lam_vals).mean())
+            beta += rng.normal(0, np.diff(beta_vals).mean())
+            A += rng.normal(0, np.diff(A_vals).mean())
+            res = gp_toy_evolve(
+                lam=lam,
+                beta=beta,
+                A=A,
+                seed=rng.integers(1e9),
+                **evolve_kwargs,
+            )
+            gnorm = res["g_norm"]
+            lbin = _bin_idx(g_bins, gnorm)
+            cell = (
+                _bin_idx(lam_vals, lam),
+                _bin_idx(beta_vals, beta),
+                _bin_idx(A_vals, A),
+                lbin,
+            )
+            if cell == tuple(target_cell):
+                successes += 1
+                break
+    return successes, attempts
+
+
+def adversarial_attack_pipeline(
+    forbidden_summary_path="results/forbidden_v0/forbidden_summary.json",
+    visited_path="results/forbidden_v0/visited_4d.npy",
+    out_path="results/forbidden_v0/adversarial_report.json",
+    max_forbidden_to_test=10,
+    strategy_attempts=20,
+    evolve_kwargs=None,
+):
+    with open(forbidden_summary_path, "r") as f:
+        summ = json.load(f)
+    visited = np.load(visited_path)
+    grid_res = int(summ["grid_res"])
+    if evolve_kwargs is None:
+        evolve_kwargs = {
+            "n": int(summ.get("n", 8)),
+            "steps": int(summ.get("steps", 200)),
+        }
+    # collect forbidden cells
+    coords = np.argwhere(~visited)
+    rng = np.random.default_rng(123)
+    rng.shuffle(coords)
+    targets = coords[: min(max_forbidden_to_test, len(coords))]
+
+    report = {"grid_res": grid_res, "tested": len(targets), "cells": []}
+    for cell in targets:
+        cell = cell.tolist()
+        res_g, tot_g = _strategy_gradient_ascent(
+            cell, grid_res, attempts=strategy_attempts, evolve_kwargs=evolve_kwargs
+        )
+        res_a, tot_a = _strategy_annealing(
+            cell, grid_res, attempts=strategy_attempts, evolve_kwargs=evolve_kwargs
+        )
+        res_b, tot_b = _strategy_bang_bang(
+            cell, grid_res, attempts=strategy_attempts, evolve_kwargs=evolve_kwargs
+        )
+        res_n, tot_n = _strategy_noise_injection(
+            cell, grid_res, attempts=strategy_attempts, evolve_kwargs=evolve_kwargs
+        )
+        cell_report = {
+            "cell": cell,
+            "gradient_ascent": {"hits": res_g, "attempts": tot_g},
+            "annealing": {"hits": res_a, "attempts": tot_a},
+            "bang_bang": {"hits": res_b, "attempts": tot_b},
+            "noise_injection": {"hits": res_n, "attempts": tot_n},
+        }
+        report["cells"].append(cell_report)
+
+    # Decision: if ANY strategy hits a target → not truly forbidden
+    any_hit = any(
+        (
+            c["gradient_ascent"]["hits"] > 0
+            or c["annealing"]["hits"] > 0
+            or c["bang_bang"]["hits"] > 0
+            or c["noise_injection"]["hits"] > 0
+        )
+        for c in report["cells"]
+    )
+    report["decision_hint"] = (
+        "NOT_TRULY_FORBIDDEN" if any_hit else "PERSISTS_AS_FORBIDDEN"
+    )
+
+    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+    with open(out_path, "w") as f:
+        json.dump(report, f, indent=2)
+    print("[adversarial] summary:", report)
+    return report
+
+
+if __name__ == "__main__":
+    adversarial_attack_pipeline()

--- a/experiments/constraint_dashboard.py
+++ b/experiments/constraint_dashboard.py
@@ -1,0 +1,3 @@
+def live_monitoring_dashboard():
+    """Placeholder for Sprint 2 implementation."""
+    return {"todo": True}

--- a/experiments/curvature_barriers.py
+++ b/experiments/curvature_barriers.py
@@ -1,0 +1,3 @@
+def curvature_barrier_analysis():
+    """Placeholder for Sprint 2 implementation."""
+    return {"todo": True}

--- a/experiments/forbidden_region_detector.py
+++ b/experiments/forbidden_region_detector.py
@@ -1,0 +1,201 @@
+import json
+import math
+import os
+import time
+
+import matplotlib
+import numpy as np
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+
+# ---------- Minimal GP toy evolution (self-contained) ----------
+# We use a simple proxy: g is an n×n coupling matrix that evolves under a
+# gradient flow driven by an "information drive" I (random but temporally
+# correlated) plus regularization terms λ, β, A. This is a toy that matches
+# our repo’s GP intuition without importing heavy internals.
+
+def _laplacian_2d(n):
+    L = np.zeros((n * n, n * n))
+    idx = lambda i, j: i * n + j
+    for i in range(n):
+        for j in range(n):
+            k = idx(i, j)
+            for di, dj in [(1, 0), (-1, 0), (0, 1), (0, -1)]:
+                ii, jj = (i + di) % n, (j + dj) % n
+                kk = idx(ii, jj)
+                L[k, k] -= 1
+                L[k, kk] += 1
+    return L
+
+
+def gp_toy_evolve(n=8, steps=200, seed=None, lam=0.5, beta=0.1, A=0.5, dt=0.05):
+    rng = np.random.default_rng(seed)
+    # state: g (n×n), I(t) (n×n)
+    g = rng.normal(0, 0.1, size=(n, n))
+    I = rng.normal(0, 1.0, size=(n, n))
+    L = _laplacian_2d(n)
+    gvec = g.reshape(-1)
+    Ivec = I.reshape(-1)
+    # simple colored noise driver for I
+    rho = 0.98
+    for t in range(steps):
+        Ivec = rho * Ivec + math.sqrt(1 - rho**2) * rng.normal(0, 1.0, size=Ivec.shape)
+        # toy "predicted" info from g (linear readout)
+        Ipred = gvec.copy()
+        grad = (
+            -(Ivec)  # drives toward info
+            + lam * gvec  # L2 regularization
+            + beta * (L @ gvec)  # smoothness
+            + A * (Ipred - Ivec)
+        )  # alignment penalty
+        gvec = gvec - dt * grad
+    g = gvec.reshape(n, n)
+    # emergent coordinates we’ll track
+    g_norm = float(np.linalg.norm(g))
+    smooth = float(gvec.T @ (L @ gvec))
+    mi_range = float(np.max(Ivec) - np.min(Ivec))
+    return {"g": g, "g_norm": g_norm, "smooth": smooth, "mi_range": mi_range}
+
+
+# ---------- 4D grid + random exploration ----------
+def minimal_forbidden_test(
+    grid_res=8,
+    n_random_runs=10_000,
+    n=8,
+    steps=200,
+    seed=0,
+    out_dir="results/forbidden_v0",
+):
+    """
+    Quick 4D scan over (λ, β, A, ||g|| target-bin). We discretize the
+    *emergent* ||g|| into grid_res bins to form a 4th axis so we can map
+    visited cells from random exploration.
+    """
+    os.makedirs(out_dir, exist_ok=True)
+    rng = np.random.default_rng(seed)
+
+    # Parameter ranges (lightweight & defensible)
+    lam_vals = np.linspace(0.1, 1.5, grid_res)
+    beta_vals = np.linspace(0.0, 0.6, grid_res)
+    A_vals = np.linspace(0.0, 1.2, grid_res)
+    g_bins = np.linspace(0.0, 5.0, grid_res + 1)  # emergent ||g|| binning
+
+    visited = np.zeros((grid_res, grid_res, grid_res, grid_res), dtype=bool)
+
+    t0 = time.time()
+    for run in range(n_random_runs):
+        lam = rng.choice(lam_vals)
+        beta = rng.choice(beta_vals)
+        A = rng.choice(A_vals)
+        res = gp_toy_evolve(
+            n=n, steps=steps, seed=rng.integers(1e9), lam=lam, beta=beta, A=A
+        )
+        gnorm = res["g_norm"]
+
+        i = int(np.clip(np.searchsorted(lam_vals, lam, side="right") - 1, 0, grid_res - 1))
+        j = int(np.clip(np.searchsorted(beta_vals, beta, side="right") - 1, 0, grid_res - 1))
+        k = int(np.clip(np.searchsorted(A_vals, A, side="right") - 1, 0, grid_res - 1))
+        l = int(np.clip(np.searchsorted(g_bins, gnorm, side="right") - 1, 0, grid_res - 1))
+        visited[i, j, k, l] = True
+
+        if (run + 1) % 1000 == 0:
+            print(f"[random] {run+1}/{n_random_runs}")
+
+    total_cells = visited.size
+    visited_count = int(visited.sum())
+    forbidden_count = total_cells - visited_count
+    forbidden_pct = 100.0 * forbidden_count / total_cells
+
+    # Largest connected forbidden component (4D adjacency = Manhattan-1)
+    # For speed, approximate by counting slices’ max area in 2D projections.
+    # (Exact 4D CC is possible but heavier; MVP goes with projections.)
+
+    def proj_largest_cc(mask2d):
+        # naive BFS CC on 2D projection
+        H, W = mask2d.shape
+        seen = np.zeros_like(mask2d, dtype=bool)
+        best = 0
+        for y in range(H):
+            for x in range(W):
+                if mask2d[y, x] and not seen[y, x]:
+                    # BFS
+                    q = [(y, x)]
+                    seen[y, x] = True
+                    c = 1
+                    while q:
+                        yy, xx = q.pop()
+                        for dy, dx in [(1, 0), (-1, 0), (0, 1), (0, -1)]:
+                            y2, x2 = yy + dy, xx + dx
+                            if (
+                                0 <= y2 < H
+                                and 0 <= x2 < W
+                                and mask2d[y2, x2]
+                                and not seen[y2, x2]
+                            ):
+                                seen[y2, x2] = True
+                                q.append((y2, x2))
+                                c += 1
+                    best = max(best, c)
+        return best
+
+    forbidden = ~visited
+    # project along each axis and take max CC as a heuristic
+    cc_scores = []
+    cc_scores.append(proj_largest_cc(forbidden.any(axis=(2, 3)).astype(int)))  # (i,j)
+    cc_scores.append(proj_largest_cc(forbidden.any(axis=(1, 3)).astype(int)))  # (i,k)
+    cc_scores.append(proj_largest_cc(forbidden.any(axis=(1, 2)).astype(int)))  # (i,l)
+    cc_scores.append(proj_largest_cc(forbidden.any(axis=(0, 3)).astype(int)))  # (j,k)
+    cc_scores.append(proj_largest_cc(forbidden.any(axis=(0, 2)).astype(int)))  # (j,l)
+    cc_scores.append(proj_largest_cc(forbidden.any(axis=(0, 1)).astype(int)))  # (k,l)
+    largest_cc_proxy = int(max(cc_scores))
+
+    # Plots: simple 2D projections of forbidden space (% forbidden per slice)
+    figdir = "figures/forbidden_v0"
+    os.makedirs(figdir, exist_ok=True)
+
+    def heat(name, arr2d, xticks, yticks, xlabel, ylabel):
+        plt.figure(figsize=(5, 4))
+        plt.imshow(100.0 * arr2d, origin="lower", aspect="auto", cmap="magma")
+        plt.colorbar(label="% forbidden")
+        plt.xlabel(xlabel)
+        plt.ylabel(ylabel)
+        plt.title(name)
+        plt.tight_layout()
+        plt.savefig(os.path.join(figdir, f"{name}.png"))
+        plt.close()
+
+    # Percent forbidden per (λ,β)
+    forb_lam_beta = forbidden.mean(axis=(2, 3))
+    heat("forbidden_lam_beta", forb_lam_beta, lam_vals, beta_vals, "λ index", "β index")
+
+    forb_lam_A = forbidden.mean(axis=(1, 3))
+    heat("forbidden_lam_A", forb_lam_A, lam_vals, A_vals, "λ index", "A index")
+
+    forb_beta_A = forbidden.mean(axis=(0, 3))
+    heat("forbidden_beta_A", forb_beta_A, beta_vals, A_vals, "β index", "A index")
+
+    summary = {
+        "grid_res": grid_res,
+        "total_cells": int(total_cells),
+        "visited_cells": visited_count,
+        "forbidden_cells": forbidden_count,
+        "forbidden_pct": forbidden_pct,
+        "largest_cc_proxy": largest_cc_proxy,
+        "random_runs": n_random_runs,
+        "n": n,
+        "steps": steps,
+        "runtime_sec": round(time.time() - t0, 3),
+        "decision_hint": "ESCALATE" if forbidden_pct > 1.0 else "STAND_DOWN",
+    }
+    with open(os.path.join(out_dir, "forbidden_summary.json"), "w") as f:
+        json.dump(summary, f, indent=2)
+
+    np.save(os.path.join(out_dir, "visited_4d.npy"), visited)
+    print("[forbidden_v0] summary:", summary)
+    return summary
+
+
+if __name__ == "__main__":
+    minimal_forbidden_test()

--- a/experiments/fractal_analysis.py
+++ b/experiments/fractal_analysis.py
@@ -1,0 +1,3 @@
+def fractal_boundary_detector():
+    """Placeholder for Sprint 2 implementation."""
+    return {"todo": True}

--- a/experiments/multi_frequency_forbidden.py
+++ b/experiments/multi_frequency_forbidden.py
@@ -1,0 +1,3 @@
+def frequency_specific_constraints():
+    """Placeholder for Sprint 2 implementation."""
+    return {"todo": True}

--- a/experiments/null_validation.py
+++ b/experiments/null_validation.py
@@ -1,0 +1,3 @@
+def null_model_suite():
+    """Placeholder for Sprint 2 implementation."""
+    return {"todo": True}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ scipy>=1.10
 matplotlib>=3.7
 pandas>=2.0
 pytest>=7.4
+networkx>=3.1
+torch>=2.0  # optional

--- a/tests/experiments/test_adversarial_smoke.py
+++ b/tests/experiments/test_adversarial_smoke.py
@@ -1,0 +1,20 @@
+import os
+
+from experiments.forbidden_region_detector import minimal_forbidden_test
+from experiments.adversarial_forcing import adversarial_attack_pipeline
+
+
+def test_adversarial_pipeline(tmp_path):
+    out = tmp_path / "res"
+    summ = minimal_forbidden_test(grid_res=4, n_random_runs=50, n=4, steps=30, out_dir=str(out))
+    # ensure visited file exists
+    assert (out / "visited_4d.npy").exists()
+    rep = adversarial_attack_pipeline(
+        forbidden_summary_path=str(out / "forbidden_summary.json"),
+        visited_path=str(out / "visited_4d.npy"),
+        out_path=str(out / "adv.json"),
+        max_forbidden_to_test=2,
+        strategy_attempts=5,
+    )
+    assert "decision_hint" in rep
+    assert os.path.exists(out / "adv.json")

--- a/tests/experiments/test_forbidden_minimal.py
+++ b/tests/experiments/test_forbidden_minimal.py
@@ -1,0 +1,10 @@
+import os
+
+from experiments.forbidden_region_detector import minimal_forbidden_test
+
+
+def test_minimal_forbidden_runs(tmp_path):
+    out = tmp_path / "res"
+    summ = minimal_forbidden_test(grid_res=4, n_random_runs=50, n=4, steps=50, out_dir=str(out))
+    assert "forbidden_pct" in summ
+    assert os.path.exists(out / "forbidden_summary.json")


### PR DESCRIPTION
## Summary
- Implemented the Task 1 minimal forbidden-region detector with 4D occupancy tracking, summary JSON emission, and projection heatmaps.
- Added the Task 2 adversarial forcing pipeline with four search strategies, JSON reporting, and configuration hooks for faster tests.
- Documented the workflow, updated quickstart instructions and dependencies, and stubbed follow-on experiment modules.

## Testing
- `pytest tests/experiments -q`

## Artifacts
- Forbidden scan summary: 87.38% forbidden (decision_hint=ESCALATE) → `results/forbidden_v0/forbidden_summary.json`
- Adversarial forcing decision: `NOT_TRULY_FORBIDDEN` → `results/forbidden_v0/adversarial_report.json`
- Heatmaps: `figures/forbidden_v0/forbidden_lam_beta.png`, `figures/forbidden_v0/forbidden_lam_A.png`, `figures/forbidden_v0/forbidden_beta_A.png`

## Checklist
- [x] experiments/forbidden_region_detector.py (MVP)
- [x] experiments/adversarial_forcing.py (MVP)
- [x] 2 smoke tests passing in CI
- [x] Docs page for Task 1
- [x] Stubs for Tasks 3–7
- [x] Plots + JSON artifacts generated locally

------
https://chatgpt.com/codex/tasks/task_e_68d9c89dfca0832cadb6106abfa2da9d