### PR TITLE
Add Makefile targets + CI mapper smoke job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,6 @@ jobs:
         run: |
           pytest -q tests/topo_test/test_skeleton_runs.py
           pytest -q || pytest -q -k ringing_threshold  # be lenient until full suite lands
+      - name: Mapper smoke (no optional deps)
+        run: |
+          make mapper-smoke

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.RECIPEPREFIX := >
+.PHONY: test smoke mapper-smoke
+
+test:
+>pytest -q
+
+smoke:
+>python -c "import json, os; os.makedirs('tmp', exist_ok=True); json.dump({'metadata':{},'bands':[{'band_id':'low','frequency_range':[0.0,1.0],'lambda_star':1.0,'hysteresis_area':0.5,'transition_sharpness':0.3,'mi_peaks':[],'trajectory':[0.0,0.5,1.0],'betti_trace':[0,1,0]}],'cross_band':{}}, open('tmp/fake.json','w'))"
+>python -m tools.resonance_mapper.cli tmp/fake.json results/mapper --tda
+
+mapper-smoke: smoke
+>@ls -la results/mapper || true
+>@ls -la figures || true


### PR DESCRIPTION
## Summary
- add a simple Makefile with test and mapper smoke targets to standardize local checks
- extend the CI workflow to run the mapper smoke to guard against regressions without optional deps

## Testing
- make mapper-smoke

------
https://chatgpt.com/codex/tasks/task_e_68d9d1aaeb14832cadd58704d6b6b487