### PR TITLE
Add live results dashboard and publishing script

### DIFF
--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -1,0 +1,91 @@
+(async function () {
+  // Data contract: publish_results.py writes these under docs/data/latest/
+  const base = 'data/latest';
+  async function loadJSON(path, fallback=null) {
+    try { const r = await fetch(path); if (!r.ok) throw 0; return await r.json(); }
+    catch { return fallback; }
+  }
+
+  const summary = await loadJSON(`${base}/summary.json`, {});
+  const forb3d = await loadJSON(`${base}/forbidden_points.json`, {accessible:[], forbidden:[]});
+  const fractal = await loadJSON(`${base}/fractal.json`, null);
+  const curvature = await loadJSON(`${base}/curvature.json`, null);
+  const hyst = await loadJSON(`${base}/hysteresis.json`, null);
+  const ring = await loadJSON(`${base}/ringing_map.json`, null);
+  const mf = await loadJSON(`${base}/multifreq.json`, null);
+
+  // HERO
+  const phase = summary.phase || 'Testing';
+  const runid = summary.run_id || '—';
+  const grade = summary.evidence_grade || '—';
+  document.getElementById('phase').textContent = phase;
+  document.getElementById('runid').textContent = runid;
+  const gEl = document.getElementById('grade'); gEl.textContent = grade;
+  gEl.style.borderColor = grade==='Strong' ? 'var(--ok)' : grade==='Moderate' ? 'var(--warn)' : 'var(--bad)';
+  document.getElementById('commit').textContent = summary.commit || 'HEAD';
+  const dl = document.getElementById('dl-summary'); dl.href = `${base}/summary.json`;
+
+  // Forbidden 3D scatter (λ, β, A) with color by reachable
+  (function drawForbidden3D() {
+    const acc = forb3d.accessible || [];
+    const forb = forb3d.forbidden || [];
+    const toXYZ = arr => arr.length ? arr.reduce((acc,p)=>{acc.x.push(p[0]); acc.y.push(p[1]); acc.z.push(p[2]); return acc;},{x:[],y:[],z:[]}) : {x:[],y:[],z:[]};
+    const A = toXYZ(acc), F = toXYZ(forb);
+    const trA = { x:A.x,y:A.y,z:A.z, mode:'markers', type:'scatter3d', name:'Accessible', marker:{size:3,color:'#3bd67f',opacity:0.7} };
+    const trF = { x:F.x,y:F.y,z:F.z, mode:'markers', type:'scatter3d', name:'Forbidden', marker:{size:4,color:'#ef476f'} };
+    Plotly.newPlot('forbidden3d', [trA, trF], {margin:{l:0,r:0,t:0,b:0}, scene:{xaxis:{title:'λ'},yaxis:{title:'β'},zaxis:{title:'A'}}}, {displayModeBar:false});
+  })();
+
+  // Fractal boundary fit (log N vs log 1/ε)
+  (function drawFractal() {
+    if (!fractal) return;
+    const xs = fractal.log_inv_eps, ys = fractal.log_counts;
+    Plotly.newPlot('fractalfit', [
+      {x:xs,y:ys,mode:'markers',name:'data',marker:{size:6}},
+      {x:xs,y:xs.map(x => fractal.fit.intercept + fractal.fit.slope*x),mode:'lines',name:`fit: slope=${fractal.fit.slope.toFixed(2)}`}
+    ], {margin:{l:40,r:10,t:10,b:40}, xaxis:{title:'log(1/ε)'}, yaxis:{title:'log N(ε)'}}, {displayModeBar:false});
+    const meta = document.getElementById('fractalmeta');
+    meta.textContent = `H ≈ ${fractal.H.toFixed(2)}  (95% CI: ${fractal.CI.map(v=>v.toFixed(2)).join(' – ')},  R²=${fractal.R2.toFixed(2)})`;
+  })();
+
+  // Curvature near boundaries
+  (function drawCurv() {
+    if (!curvature) return;
+    Plotly.newPlot('curvature', [{
+      x: curvature.dist || [], y: curvature.kappa || [],
+      mode:'markers', type:'scatter', name:'κ vs distance', marker:{size:6,color:'#9ecbff'}
+    }], {margin:{l:40,r:10,t:10,b:40}, xaxis:{title:'distance to boundary'}, yaxis:{title:'Ollivier–Ricci κ'}}, {displayModeBar:false});
+    const hit = (curvature.coverage || 0)*100;
+    document.getElementById('curvemeta').textContent = `Coverage κ<-0.1: ${hit.toFixed(1)}%  |  Mean κ: ${(+curvature.mean).toFixed(3)}`;
+  })();
+
+  // Hysteresis placeholder (populates when docs/data/latest/hysteresis.json exists)
+  (function drawHyst() {
+    if (!hyst) return;
+    Plotly.newPlot('hyst', [{
+      x: hyst.loop_x, y: hyst.loop_y, mode:'lines', name:'loop'
+    }], {margin:{l:40,r:10,t:10,b:40}, xaxis:{title:'drive'}, yaxis:{title:'response'}}, {displayModeBar:false});
+  })();
+
+  // Ringing boundary map placeholder
+  (function drawRing() {
+    if (!ring) return;
+    Plotly.newPlot('ringing', [{
+      z: ring.phase_map, type:'heatmap', colorscale:'Jet'
+    }], {margin:{l:40,r:10,t:10,b:40}, xaxis:{title:'α'}, yaxis:{title:'η'}}, {displayModeBar:false});
+  })();
+
+  // Multi-frequency placeholder
+  (function drawMF() {
+    if (!mf) return;
+    Plotly.newPlot('multifreq', [{
+      x: mf.bands, y: mf.lambda_star, type:'bar', name:'λ* by band'
+    }], {margin:{l:40,r:10,t:10,b:40}, yaxis:{title:'λ*'}}, {displayModeBar:false});
+  })();
+
+  // Validation badges
+  document.getElementById('surrogate').textContent = summary.surrogates_pass ?? '—';
+  document.getElementById('mcc').textContent = summary.mcc ?? '—';
+  document.getElementById('nulls').textContent = summary.nulls ?? '—';
+  document.getElementById('repl').textContent = summary.replicates ?? '—';
+})();

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -1,0 +1,16 @@
+:root { --bg:#0b0d12; --fg:#e8ecf3; --muted:#97a0ad; --ok:#3bd67f; --warn:#ffd166; --bad:#ef476f; --card:#121621; }
+*{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--fg);font:16px/1.5 system-ui,-apple-system,Segoe UI,Roboto}
+.hero{padding:28px 20px;border-bottom:1px solid #1d2330}
+.hero h1{margin:0 0 10px;font-weight:650}
+#status{display:flex;gap:24px;flex-wrap:wrap;color:var(--muted)}
+.cta a{margin-right:12px;color:#9ecbff;text-decoration:none}
+.grid{padding:20px;display:grid;gap:18px}
+section{background:var(--card);border:1px solid #1d2330;border-radius:10px;padding:16px}
+.row{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+.panel{background:#0f1320;border:1px solid #1c2230;border-radius:8px;padding:12px}
+.plot{width:100%;height:360px}
+.kpis ul{list-style:none;padding:0;margin:0}
+.kpis li{margin:8px 0}
+.grade{padding:2px 8px;border-radius:6px;border:1px solid #2a3346}
+footer{padding:16px;color:var(--muted);text-align:center;border-top:1px solid #1d2330}
+@media (max-width:950px){.row{grid-template-columns:1fr}}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,117 +1,79 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Resonance Geometry — Live Dashboard</title>
-  <link rel="stylesheet" href="./style.css">
-  <meta name="description" content="Latest simulations for the Resonance Geometry project: forbidden regions, fractal boundary scaling, curvature barriers, and mapper/TDA.">
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Resonance Geometry — Live Results</title>
+  <link rel="stylesheet" href="assets/style.css"/>
+  <script src="https://cdn.plot.ly/plotly-2.32.0.min.js"></script>
 </head>
 <body>
-  <header class="header">
-    <h1>Resonance Geometry</h1>
-    <p class="tag">Listen Deep · Question Hard · Weave Truth and Pattern · No Fluff</p>
-    <nav class="nav">
-      <a href="https://github.com/justindbilyeu/Resonance_Geometry">Repo</a>
-      <a href="https://github.com/justindbilyeu/Resonance_Geometry/wiki">Wiki</a>
-      <a href="#latest">Latest Simulations</a>
-    </nav>
+  <header class="hero">
+    <h1>Geometric Plasticity: Live Results</h1>
+    <div id="status">
+      <div><b>Current Status:</b> <span id="phase">Loading…</span></div>
+      <div><b>Latest Run:</b> <span id="runid">Loading…</span></div>
+      <div><b>Evidence Grade:</b> <span id="grade" class="grade">Loading…</span></div>
+    </div>
+    <div class="cta">
+      <a href="https://github.com/justindbilyeu/Resonance_Geometry" target="_blank">Repo</a>
+      <a href="https://github.com/justindbilyeu/Resonance_Geometry/wiki" target="_blank">Wiki</a>
+    </div>
   </header>
 
-  <main id="latest" class="container">
-    <section class="grid">
-      <article class="card" id="forbidden-card">
-        <h2>Forbidden Regions (Topological Constraint)</h2>
-        <ul class="kv">
-          <li><span>% Forbidden</span><strong data-bind="forbiddenPct">N/A</strong></li>
-          <li><span>Largest component</span><strong data-bind="largestComp">N/A</strong></li>
-          <li><span>Runs</span><strong data-bind="runs">N/A</strong></li>
-        </ul>
-        <div class="media" data-img="forbiddenPlot"></div>
-        <details><summary>More</summary>
-          <pre class="mono" data-pre="forbiddenJson">No summary file found.</pre>
-        </details>
-      </article>
-
-      <article class="card" id="fractal-card">
-        <h2>Fractal Boundary (Box-counting)</h2>
-        <ul class="kv">
-          <li><span>H (median)</span><strong data-bind="H">N/A</strong></li>
-          <li><span>R²</span><strong data-bind="r2">N/A</strong></li>
-          <li><span>95% CI</span><strong data-bind="ci">N/A</strong></li>
-        </ul>
-        <div class="media" data-img="fractalPlot"></div>
-        <details><summary>More</summary>
-          <pre class="mono" data-pre="fractalJson">No summary file found.</pre>
-        </details>
-      </article>
-
-      <article class="card" id="ricci-card">
-        <h2>Curvature Barriers (Ollivier–Ricci)</h2>
-        <ul class="kv">
-          <li><span>Average κ</span><strong data-bind="avgKappa">N/A</strong></li>
-          <li><span>Boundary coverage</span><strong data-bind="coverage">N/A</strong></li>
-        </ul>
-        <div class="media" data-img="ricciPlot"></div>
-        <details><summary>More</summary>
-          <pre class="mono" data-pre="ricciJson">No summary file found.</pre>
-        </details>
-      </article>
-
-      <article class="card" id="mapper-card">
-        <h2>Resonance Mapper (GNN + TDA)</h2>
-        <ul class="kv">
-          <li><span>Betti (β₀,β₁,β₂)</span><strong data-bind="betti">N/A</strong></li>
-          <li><span>Embeddings</span><strong data-bind="embeddings">N/A</strong></li>
-        </ul>
-        <div class="media" data-img="mapperPlot"></div>
-        <details><summary>More</summary>
-          <pre class="mono" data-pre="mapperJson">No report found.</pre>
-        </details>
-      </article>
+  <main class="grid">
+    <section>
+      <h2>Forbidden Region Detection</h2>
+      <div class="row">
+        <div class="panel">
+          <h3>Accessible vs. Forbidden (3D)</h3>
+          <div id="forbidden3d" class="plot"></div>
+        </div>
+        <div class="panel">
+          <h3>Boundary Fractal Fit</h3>
+          <div id="fractalfit" class="plot"></div>
+          <div id="fractalmeta" class="meta"></div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="panel">
+          <h3>Curvature Near Boundaries</h3>
+          <div id="curvature" class="plot"></div>
+          <div id="curvemeta" class="meta"></div>
+        </div>
+        <div class="panel kpis">
+          <h3>Validation Suite</h3>
+          <ul id="validation">
+            <li>Surrogate controls: <span id="surrogate">—</span></li>
+            <li>Multiple-comparison control: <span id="mcc">—</span></li>
+            <li>Null models: <span id="nulls">—</span></li>
+            <li>Replication: <span id="repl">—</span></li>
+          </ul>
+          <a id="dl-summary" href="#" download>Download summary.json</a>
+        </div>
+      </div>
     </section>
 
-    <section class="gallery">
-      <h2>Figures</h2>
-      <div class="figs" id="figs">
-        <!-- auto-populated from ./figures -->
-      </div>
+    <section>
+      <h2>Hysteresis</h2>
+      <div id="hyst" class="plot"></div>
+    </section>
+
+    <section>
+      <h2>Ringing Boundary Map</h2>
+      <div id="ringing" class="plot"></div>
+    </section>
+
+    <section>
+      <h2>Multi-Frequency (alpha/β/γ) — when available</h2>
+      <div id="multifreq" class="plot"></div>
     </section>
   </main>
 
-  <footer class="footer">
-    <span>© Resonance Geometry</span>
-    <span>Build: <code id="build-hash">…</code></span>
+  <footer>
+    <code>Reproduce: git checkout <span id="commit">HEAD</span> && python scripts/run_phase_sweep.py --seed 42</code>
   </footer>
 
-  <script src="./app.js"></script>
+  <script src="assets/app.js"></script>
 </body>
-<style>
-/* tiny inline fallback for quick load; full styles in style.css */
-body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial,sans-serif;margin:0;color:#111}
-.header{padding:24px 20px;border-bottom:1px solid #eee}
-.header h1{margin:0;font-weight:700}
-.tag{margin:6px 0 0 0;color:#555}
-.nav a{margin-right:12px;color:#0a58ca;text-decoration:none}
-.container{padding:24px 20px}
-.grid{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(280px,1fr))}
-.card{border:1px solid #e6e6e6;border-radius:10px;padding:16px;background:#fff;box-shadow:0 1px 2px rgba(0,0,0,.04)}
-.kv{list-style:none;padding:0;margin:0 0 10px 0}
-.kv li{display:flex;justify-content:space-between;margin:6px 0}
-.kv span{color:#555}
-.media{margin-top:10px;min-height:120px;background:#fafafa;border:1px dashed #ddd;border-radius:8px;display:flex;align-items:center;justify-content:center}
-.mono{white-space:pre-wrap;font-family:ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;background:#fafafa;border:1px solid #eee;border-radius:8px;padding:8px}
-.gallery h2{margin-top:36px}
-.figs{display:grid;gap:10px;grid-template-columns:repeat(auto-fit,minmax(180px,1fr))}
-.figs img{width:100%;height:auto;border:1px solid #eee;border-radius:8px}
-.footer{padding:16px 20px;border-top:1px solid #eee;color:#666;display:flex;justify-content:space-between}
-@media (prefers-color-scheme: dark){
-  body{background:#0b0b0c;color:#eaeaea}
-  .card{background:#111214;border-color:#262626}
-  .media{background:#141416;border-color:#2a2a2a}
-  .mono{background:#111214;border-color:#2a2a2a}
-  .header{border-bottom-color:#222}
-  .footer{border-top-color:#222}
-}
-</style>
 </html>

--- a/scripts/publish_results.py
+++ b/scripts/publish_results.py
@@ -1,0 +1,74 @@
+"""
+Collect latest run artifacts and publish a normalized bundle for GitHub Pages.
+Usage:
+  python scripts/publish_results.py --run results/topo_test/run_YYYYMMDD_HHMM --out docs/data/latest
+"""
+import argparse
+import json
+from pathlib import Path
+
+
+def load_json(p):
+    try:
+        with open(p, "r") as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--run", required=True)
+    ap.add_argument("--out", default="docs/data/latest")
+    args = ap.parse_args()
+
+    run = Path(args.run)
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    # Expected inputs (gracefully optional)
+    summary = load_json(run / "summary.json") or {}
+    forb_points = load_json(run / "forbidden_points.json") or {"accessible": [], "forbidden": []}
+    fractal = load_json(run / "fractal" / "fractal.json")
+    curvature = load_json(run / "curvature" / "curvature.json")
+    hyst = load_json(run / "hysteresis.json")
+    ring = load_json("results/ringing_map.json")
+    mf = load_json("results/multi_frequency_results.json")
+
+    # Normalize fractal for front-end
+    if fractal and "scales" in fractal and "counts" in fractal:
+        import numpy as np
+
+        eps = (1.0 / (np.array(fractal["scales"], dtype=float))).tolist()
+        log_inv = [float(-1 * __import__("math").log(e)) for e in eps]  # log(1/ε)
+        log_counts = [float(__import__("math").log(c)) for c in fractal["counts"]]
+        fractal = {
+            "H": float(fractal.get("H", 0)),
+            "R2": float(fractal.get("r2", 0)),
+            "CI": fractal.get("ci", [0, 0]),
+            "log_inv_eps": log_inv,
+            "log_counts": log_counts,
+            "fit": {"slope": float(fractal.get("H", 0)), "intercept": 0.0},
+        }
+
+    # Write bundle
+    with open(out / "summary.json", "w") as f:
+        json.dump(summary, f, indent=2)
+    with open(out / "forbidden_points.json", "w") as f:
+        json.dump(forb_points, f, indent=2)
+    if fractal:
+        (out / "fractal.json").write_text(json.dumps(fractal, indent=2))
+    if curvature:
+        (out / "curvature.json").write_text(json.dumps(curvature, indent=2))
+    if hyst:
+        (out / "hysteresis.json").write_text(json.dumps(hyst, indent=2))
+    if ring:
+        (out / "ringing_map.json").write_text(json.dumps(ring, indent=2))
+    if mf:
+        (out / "multifreq.json").write_text(json.dumps(mf, indent=2))
+
+    print(f"Published dashboard bundle from {run} → {out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- replace the docs landing page with a live results dashboard layout backed by Plotly charts
- add dashboard styling and client script that hydrate plots from the latest published JSON bundle
- provide a publish_results.py helper to normalize simulation artifacts into the docs/data/latest bundle for GitHub Pages

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d9d9ac14d0832c98bdc163341f021e