### PR TITLE
Revamp docs landing page layout

### DIFF
--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -14,3 +14,9 @@ section{background:var(--card);border:1px solid #1d2330;border-radius:10px;paddi
 .grade{padding:2px 8px;border-radius:6px;border:1px solid #2a3346}
 footer{padding:16px;color:var(--muted);text-align:center;border-top:1px solid #1d2330}
 @media (max-width:950px){.row{grid-template-columns:1fr}}
+.lede{color:var(--muted);max-width:900px;margin:8px 0 14px}
+.banner{background:#1e2536;border:1px solid #2a3346;color:#cfe0ff;padding:10px 14px;margin:14px 20px;border-radius:8px}
+.banner a{color:#9ecbff}
+.status{margin-top:8px}
+.muted{color:var(--muted)}
+.code{background:#0c101a;border:1px solid #1d2330;border-radius:8px;padding:10px;overflow:auto}

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,37 +9,55 @@
 </head>
 <body>
   <header class="hero">
-    <h1>Geometric Plasticity: Live Results</h1>
-    <div id="status">
+    <h1>Geometric Plasticity: Testing Information–Structure Coupling</h1>
+    <p class="lede">
+      We’re empirically testing whether geometric constraints emerge in information-coupled networks.
+      The sections below surface **validated computations** first; clearly labeled exploratory
+      extensions appear later. Reproduce everything from the main repo.
+    </p>
+    <div id="status" class="status">
       <div><b>Current Status:</b> <span id="phase">Loading…</span></div>
       <div><b>Latest Run:</b> <span id="runid">Loading…</span></div>
       <div><b>Evidence Grade:</b> <span id="grade" class="grade">Loading…</span></div>
     </div>
-    <div class="cta">
-      <a href="https://github.com/justindbilyeu/Resonance_Geometry" target="_blank">Repo</a>
-      <a href="https://github.com/justindbilyeu/Resonance_Geometry/wiki" target="_blank">Wiki</a>
-    </div>
+    <nav class="cta">
+      <a href="https://github.com/justindbilyeu/Resonance_Geometry" target="_blank">Main Repository</a>
+      <a href="https://github.com/justindbilyeu/Resonance_Geometry/wiki" target="_blank">Wiki (Protocols)</a>
+      <a href="https://github.com/justindbilyeu/Resonance_Geometry/tree/main/docs" target="_blank">This Site Source</a>
+    </nav>
   </header>
 
+  <!-- Epistemic banner -->
+  <aside class="banner">
+    ⚠️ This site includes exploratory, speculative sections.
+    For validated computational results and exact reproduction steps, see the
+    <a href="https://github.com/justindbilyeu/Resonance_Geometry" target="_blank">Main Repository</a>
+    and <a href="https://github.com/justindbilyeu/Resonance_Geometry/wiki" target="_blank">Wiki</a>.
+  </aside>
+
   <main class="grid">
+    <!-- TIER 1: VALIDATED / RESULTS-FIRST -->
     <section>
-      <h2>Forbidden Region Detection</h2>
+      <h2>Tier 1 — Validated/Testing Results</h2>
+
       <div class="row">
         <div class="panel">
-          <h3>Accessible vs. Forbidden (3D)</h3>
-          <div id="forbidden3d" class="plot"></div>
+          <h3>Ringing Boundary Map</h3>
+          <p class="muted">Phase map from simulations: smooth → critical → ringing.</p>
+          <div id="ringing" class="plot"></div>
         </div>
         <div class="panel">
-          <h3>Boundary Fractal Fit</h3>
-          <div id="fractalfit" class="plot"></div>
-          <div id="fractalmeta" class="meta"></div>
+          <h3>Hysteresis</h3>
+          <p class="muted">Loop structure and resonance peaks with confidence bands (when available).</p>
+          <div id="hyst" class="plot"></div>
         </div>
       </div>
+
       <div class="row">
         <div class="panel">
-          <h3>Curvature Near Boundaries</h3>
-          <div id="curvature" class="plot"></div>
-          <div id="curvemeta" class="meta"></div>
+          <h3>Forbidden Region Detection (Live)</h3>
+          <p class="muted">3D projection of accessible vs. forbidden parameter cells (λ, β, A).</p>
+          <div id="forbidden3d" class="plot"></div>
         </div>
         <div class="panel kpis">
           <h3>Validation Suite</h3>
@@ -52,26 +70,71 @@
           <a id="dl-summary" href="#" download>Download summary.json</a>
         </div>
       </div>
+
+      <div class="row">
+        <div class="panel">
+          <h3>Boundary Fractal Fit</h3>
+          <div id="fractalfit" class="plot"></div>
+          <div id="fractalmeta" class="meta"></div>
+        </div>
+        <div class="panel">
+          <h3>Curvature Near Boundaries</h3>
+          <div id="curvature" class="plot"></div>
+          <div id="curvemeta" class="meta"></div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="panel">
+          <h3>Multi-Frequency (alpha/β/γ)</h3>
+          <p class="muted">λ* thresholds and cross-band patterns (auto-populates when available).</p>
+          <div id="multifreq" class="plot"></div>
+        </div>
+        <div class="panel">
+          <h3>Reproducibility</h3>
+          <pre class="code">
+git clone https://github.com/justindbilyeu/Resonance_Geometry
+cd Resonance_Geometry
+git checkout <span id="commit">HEAD</span>
+python scripts/run_phase_sweep.py --seed 42
+          </pre>
+        </div>
+      </div>
     </section>
 
+    <!-- TIER 2: CLEARLY-LABELED EXPLORATIONS -->
     <section>
-      <h2>Hysteresis</h2>
-      <div id="hyst" class="plot"></div>
-    </section>
-
-    <section>
-      <h2>Ringing Boundary Map</h2>
-      <div id="ringing" class="plot"></div>
-    </section>
-
-    <section>
-      <h2>Multi-Frequency (alpha/β/γ) — when available</h2>
-      <div id="multifreq" class="plot"></div>
+      <h2>Tier 2 — Exploratory Extensions (Clearly Labeled)</h2>
+      <p class="muted">
+        The following sections explore theoretical extensions (e.g., consciousness, cosmology analogs).
+        These are hypothesis-generating, not validated findings.
+      </p>
+      <div class="row">
+        <div class="panel">
+          <h3>Concept Bridges (Exploration)</h3>
+          <ul class="muted">
+            <li>Consciousness geometry as information manifold (exploratory)</li>
+            <li>Ring resonator holonomy analogs to redshift (exploratory)</li>
+            <li>Topological constraints &amp; awareness nodes (exploratory)</li>
+          </ul>
+          <p><a href="https://github.com/justindbilyeu/Resonance_Geometry/wiki" target="_blank">Read protocols &amp; prereg</a></p>
+        </div>
+        <div class="panel">
+          <h3>Data &amp; Methods Index</h3>
+          <ul>
+            <li><a href="https://github.com/justindbilyeu/Resonance_Geometry/tree/main/experiments" target="_blank">Experiments</a></li>
+            <li><a href="https://github.com/justindbilyeu/Resonance_Geometry/tree/main/tools" target="_blank">Tools (Ricci, Fractal, Mapper)</a></li>
+            <li><a href="https://github.com/justindbilyeu/Resonance_Geometry/tree/main/results" target="_blank">Results (raw artifacts)</a></li>
+          </ul>
+        </div>
+      </div>
     </section>
   </main>
 
   <footer>
-    <code>Reproduce: git checkout <span id="commit">HEAD</span> && python scripts/run_phase_sweep.py --seed 42</code>
+    <small class="muted">
+      Results update when new JSON bundles are published. Pages can take a few minutes to refresh.
+    </small>
   </footer>
 
   <script src="assets/app.js"></script>


### PR DESCRIPTION
## Summary
- restructure the docs landing page to foreground validated analyses, navigation links, and exploratory disclaimers
- add an epistemic banner plus reproducibility snippet and tiered content sections
- extend the shared stylesheet with utilities for the new banner, lede text, muted copy, and code blocks

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d9e4600adc832c82a59397b1adba65