### PR TITLE
Add fractal and Ricci utility modules for result pipeline

### DIFF
--- a/tools/fractal.py
+++ b/tools/fractal.py
@@ -1,0 +1,129 @@
+"""Utility routines for estimating fractal dimension via box counting."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+
+__all__ = ["BoxCountStats", "boxcount_dimension"]
+
+
+@dataclass(slots=True)
+class BoxCountStats:
+    """Container describing a fitted box-counting curve."""
+
+    scales: np.ndarray
+    counts: np.ndarray
+    slope: float
+    intercept: float
+    r2: float
+    ci: tuple[float, float]
+
+
+def _prepare_points(mask: np.ndarray) -> np.ndarray:
+    if mask.ndim != 2:
+        raise ValueError("boxcount_dimension expects a 2D binary mask")
+    if mask.size == 0:
+        return np.zeros((0, 2), dtype=int)
+    coords = np.argwhere(mask.astype(bool))
+    return coords.astype(float, copy=False)
+
+
+def _choose_scales(points: np.ndarray, n_scales: int) -> np.ndarray:
+    if points.shape[0] == 0:
+        return np.asarray([], dtype=float)
+    span = points.max(axis=0) - points.min(axis=0) + 1.0
+    max_extent = float(np.max(span))
+    max_extent = max(max_extent, 2.0)
+    raw = np.logspace(0.0, math.log10(max_extent), num=n_scales)
+    scales = np.unique(np.clip(np.floor(raw + 1e-8).astype(int), 1, None))
+    return scales.astype(float)
+
+
+def _box_counts(points: np.ndarray, scales: Iterable[float]) -> np.ndarray:
+    if points.shape[0] == 0:
+        return np.zeros(len(list(scales)), dtype=float)
+    mins = points.min(axis=0)
+    shifted = points - mins
+    counts = []
+    for scale in scales:
+        step = max(int(round(scale)), 1)
+        bins = np.floor_divide(shifted, step)
+        unique = np.unique(bins, axis=0)
+        counts.append(float(unique.shape[0]))
+    return np.asarray(counts, dtype=float)
+
+
+def _fit_line(x: np.ndarray, y: np.ndarray) -> tuple[float, float, float]:
+    slope, intercept = np.polyfit(x, y, 1)
+    pred = slope * x + intercept
+    ss_res = float(np.sum((y - pred) ** 2))
+    ss_tot = float(np.sum((y - y.mean()) ** 2))
+    r2 = 1.0 - ss_res / ss_tot if ss_tot > 0 else float("nan")
+    return float(slope), float(intercept), r2
+
+
+def boxcount_dimension(
+    mask: np.ndarray,
+    *,
+    n_scales: int = 12,
+    n_boot: int = 200,
+    seed: int | None = None,
+) -> dict[str, object]:
+    """Estimate the fractal dimension of a 2D binary mask.
+
+    Parameters
+    ----------
+    mask:
+        Boolean or numeric array where non-zero entries indicate boundary pixels.
+    n_scales:
+        Number of geometric scales used for the box-counting regression.
+    n_boot:
+        Number of bootstrap resamples used to derive a 95% confidence interval.
+    seed:
+        Optional RNG seed to make the bootstrap deterministic.
+    """
+
+    points = _prepare_points(np.asarray(mask))
+    if points.shape[0] < 2:
+        return {"H": float("nan"), "r2": float("nan"), "ci": (float("nan"), float("nan"))}
+
+    scales = _choose_scales(points, n_scales)
+    if scales.size < 2:
+        return {"H": float("nan"), "r2": float("nan"), "ci": (float("nan"), float("nan"))}
+
+    counts = _box_counts(points, scales)
+    valid = counts > 0
+    if valid.sum() < 2:
+        return {"H": float("nan"), "r2": float("nan"), "ci": (float("nan"), float("nan"))}
+
+    counts = counts[valid]
+    scales = scales[valid]
+
+    log_counts = np.log(counts)
+    log_inv_scale = np.log(1.0 / scales)
+    slope, intercept, r2 = _fit_line(log_inv_scale, log_counts)
+
+    rng = np.random.default_rng(seed)
+    n_points = points.shape[0]
+    boot = np.empty(n_boot, dtype=float)
+    for i in range(n_boot):
+        sample_idx = rng.integers(0, n_points, size=n_points)
+        sample_points = points[sample_idx]
+        sample_counts = _box_counts(sample_points, scales)
+        if np.any(sample_counts <= 0):
+            boot[i] = float("nan")
+            continue
+        log_counts_bs = np.log(sample_counts)
+        slope_bs, _, _ = _fit_line(log_inv_scale, log_counts_bs)
+        boot[i] = slope_bs
+
+    boot = boot[np.isfinite(boot)]
+    if boot.size == 0:
+        ci = (float("nan"), float("nan"))
+    else:
+        ci = tuple(np.percentile(boot, [2.5, 97.5]).astype(float))  # type: ignore[assignment]
+
+    return {"H": slope, "r2": r2, "ci": ci, "scales": scales.tolist(), "counts": counts.tolist()}

--- a/tools/ricci.py
+++ b/tools/ricci.py
@@ -1,0 +1,127 @@
+"""Lightweight Ollivier--Ricci curvature utilities for grid-based experiments."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Mapping, Tuple
+
+import networkx as nx
+import numpy as np
+from scipy.optimize import linprog
+
+__all__ = ["ollivier_ricci"]
+
+
+@dataclass(slots=True)
+class _Measure:
+    support: list[object]
+    mass: np.ndarray
+
+
+def _node_measure(graph: nx.Graph, node: object, alpha: float) -> _Measure:
+    neighbors = list(graph.neighbors(node))
+    support = [node] + neighbors
+    mass = np.empty(len(support), dtype=float)
+    if neighbors:
+        mass[0] = alpha
+        mass[1:] = (1.0 - alpha) / len(neighbors)
+    else:
+        mass[0] = 1.0
+    return _Measure(support=support, mass=mass)
+
+
+def _all_pairs_distances(graph: nx.Graph) -> Mapping[object, Mapping[object, float]]:
+    return {node: dict(lengths) for node, lengths in nx.all_pairs_shortest_path_length(graph)}
+
+
+def _earth_mover_distance(
+    support_a: Iterable[object],
+    support_b: Iterable[object],
+    mass_a: np.ndarray,
+    mass_b: np.ndarray,
+    distances: Mapping[object, Mapping[object, float]],
+) -> float:
+    sup_a = list(support_a)
+    sup_b = list(support_b)
+    m, n = len(sup_a), len(sup_b)
+    cost = np.zeros((m, n), dtype=float)
+    for i, node_a in enumerate(sup_a):
+        da = distances[node_a]
+        for j, node_b in enumerate(sup_b):
+            cost[i, j] = da.get(node_b, np.inf)
+    if not np.isfinite(cost).all():
+        finite = cost[np.isfinite(cost)]
+        if finite.size == 0:
+            raise RuntimeError("Disconnected supports encountered in EMD computation")
+        penalty = float(finite.max() * 2.0)
+        cost[~np.isfinite(cost)] = penalty
+    cvec = cost.reshape(-1)
+
+    a_eq = []
+    b_eq = []
+    for i in range(m):
+        row = np.zeros(m * n)
+        row[i * n : (i + 1) * n] = 1.0
+        a_eq.append(row)
+        b_eq.append(mass_a[i])
+    for j in range(n):
+        row = np.zeros(m * n)
+        row[j::n] = 1.0
+        a_eq.append(row)
+        b_eq.append(mass_b[j])
+    bounds = [(0.0, None)] * (m * n)
+    result = linprog(
+        cvec,
+        A_eq=np.asarray(a_eq),
+        b_eq=np.asarray(b_eq),
+        bounds=bounds,
+        method="highs",
+    )
+    if not result.success:
+        raise RuntimeError(f"linprog failed: {result.message}")
+    return float(result.fun)
+
+
+def ollivier_ricci(
+    graph: nx.Graph,
+    *,
+    alpha: float = 0.5,
+    method: str | None = None,
+) -> Tuple[Dict[Tuple[object, object], float], float]:
+    """Compute Ollivier--Ricci curvature for each edge in ``graph``.
+
+    Parameters
+    ----------
+    graph:
+        NetworkX graph (treated as unweighted) describing the adjacency.
+    alpha:
+        Idle mass retained at each node. ``alpha=0`` recovers the usual lazy random walk.
+    method:
+        Currently ignored; present for API compatibility with historical callers.
+    """
+
+    if not 0.0 <= alpha <= 1.0:
+        raise ValueError("alpha must lie in [0, 1]")
+
+    distances = _all_pairs_distances(graph)
+    measures = {node: _node_measure(graph, node, alpha) for node in graph.nodes}
+
+    ricci: Dict[Tuple[object, object], float] = {}
+    values = []
+    undirected = not graph.is_directed()
+    for u, v in graph.edges:
+        mu = measures[u]
+        mv = measures[v]
+        w1 = _earth_mover_distance(mu.support, mv.support, mu.mass, mv.mass, distances)
+        kappa = 1.0 - w1  # edge length assumed to be 1
+        if undirected:
+            try:
+                key = (u, v) if u <= v else (v, u)
+            except TypeError:
+                ordered = sorted((u, v), key=repr)
+                key = (ordered[0], ordered[1])
+        else:
+            key = (u, v)
+        ricci[key] = float(kappa)
+        values.append(kappa)
+    avg = float(np.mean(values)) if values else float("nan")
+    return ricci, avg


### PR DESCRIPTION
## Summary
- implement a reusable box-counting helper in `tools/fractal.py` for estimating forbidden-boundary dimensions
- add a lightweight Ollivier–Ricci curvature routine in `tools/ricci.py` for the curvature barrier analysis

## Testing
- pytest tests/test_fractal_estimator.py

------
https://chatgpt.com/codex/tasks/task_e_68d9e9976ea4832cbaf3ca8b4868e6ec