### PR TITLE
Add validation progress visualization to dashboard

### DIFF
--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -1,3 +1,18 @@
+function updateProgress(data) {
+  const prog = data?.progress || {};
+  const pairs = [
+    ['bar-core', prog.core],
+    ['bar-forbidden', prog.forbidden],
+    ['bar-fractal', prog.fractal],
+    ['bar-curvature', prog.curvature],
+    ['bar-null', prog.nulls]
+  ];
+  pairs.forEach(([id, val]) => {
+    const el = document.getElementById(id);
+    if (el) el.style.width = ((val ?? 0)) + '%';
+  });
+}
+
 (async function () {
   // Data contract: publish_results.py writes these under docs/data/latest/
   const base = 'data/latest';
@@ -7,6 +22,7 @@
   }
 
   const summary = await loadJSON(`${base}/summary.json`, {});
+  const status = await loadJSON('data/status/summary.json', {});
   const forb3d = await loadJSON(`${base}/forbidden_points.json`, {accessible:[], forbidden:[]});
   const fractal = await loadJSON(`${base}/fractal.json`, null);
   const curvature = await loadJSON(`${base}/curvature.json`, null);
@@ -24,6 +40,7 @@
   gEl.style.borderColor = grade==='Strong' ? 'var(--ok)' : grade==='Moderate' ? 'var(--warn)' : 'var(--bad)';
   document.getElementById('commit').textContent = summary.commit || 'HEAD';
   const dl = document.getElementById('dl-summary'); dl.href = `${base}/summary.json`;
+  updateProgress(status);
 
   // Forbidden 3D scatter (λ, β, A) with color by reachable
   (function drawForbidden3D() {

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -3,6 +3,10 @@
 .hero{padding:28px 20px;border-bottom:1px solid #1d2330}
 .hero h1{margin:0 0 10px;font-weight:650}
 #status{display:flex;gap:24px;flex-wrap:wrap;color:var(--muted)}
+#progress{margin:2em 0}
+.bar{margin:.5em 0;background:#eee;border-radius:4px;overflow:hidden}
+.bar span{display:block;font-size:14px;margin:.2em 0}
+.fill{height:12px;background:#0b84f3;width:0%;transition:width .8s ease}
 .cta a{margin-right:12px;color:#9ecbff;text-decoration:none}
 .grid{padding:20px;display:grid;gap:18px}
 section{background:var(--card);border:1px solid #1d2330;border-radius:10px;padding:16px}

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,6 +27,15 @@
     </nav>
   </header>
 
+  <div id="progress">
+    <h2>Validation Progress</h2>
+    <div class="bar"><span>Core GP framework</span><div class="fill" id="bar-core"></div></div>
+    <div class="bar"><span>Forbidden region detection</span><div class="fill" id="bar-forbidden"></div></div>
+    <div class="bar"><span>Fractal boundary analysis</span><div class="fill" id="bar-fractal"></div></div>
+    <div class="bar"><span>Curvature barrier detection</span><div class="fill" id="bar-curvature"></div></div>
+    <div class="bar"><span>Null model validation</span><div class="fill" id="bar-null"></div></div>
+  </div>
+
   <!-- Epistemic banner -->
   <aside class="banner">
     ⚠️ This site includes exploratory, speculative sections.


### PR DESCRIPTION
## Summary
- add a validation progress section beneath the hero header
- style progress bars to display progress levels consistently
- load the status summary progress data and update the new bars

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68daaafb02c8832c82e4bc8826dac442