### PR TITLE
Use np.trapz for GP integrations

### DIFF
--- a/experiments/run_multi_frequency_gp.py
+++ b/experiments/run_multi_frequency_gp.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import sys
+import warnings
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -13,6 +14,12 @@ from typing import Dict, Iterable, List, Sequence, Tuple
 
 import numpy as np
 from scipy.signal import butter, filtfilt, welch
+
+warnings.filterwarnings(
+    "ignore",
+    message=r".*`trapz` is deprecated.*",
+    category=DeprecationWarning,
+)
 
 
 def _ensure_repo_on_path() -> None:
@@ -67,7 +74,13 @@ def _band_power(values: np.ndarray, fs: float, band: Tuple[float, float]) -> flo
     mask = (freqs >= band[0]) & (freqs <= band[1])
     if not np.any(mask):
         return 0.0
-    return float(np.trapezoid(psd[mask], freqs[mask]))
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r".*`trapz` is deprecated.*",
+            category=DeprecationWarning,
+        )
+        return float(np.trapz(psd[mask], freqs[mask]))
 
 
 def _aggregate_by_lambda(
@@ -125,7 +138,13 @@ def _compute_hysteresis(
 
     up_filled = _fill_nan_interp(centers, up_vals)
     down_filled = _fill_nan_interp(centers, down_vals)
-    area = float(np.trapezoid(np.abs(up_filled - down_filled), centers))
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r".*`trapz` is deprecated.*",
+            category=DeprecationWarning,
+        )
+        area = float(np.trapz(np.abs(up_filled - down_filled), centers))
     return area, centers, up_filled, down_filled
 
 

--- a/scripts/gp_ringing_demo.py
+++ b/scripts/gp_ringing_demo.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+import warnings
 from typing import Dict, Mapping, MutableMapping
 
 import matplotlib
@@ -15,6 +16,12 @@ import numpy as np
 from scipy.signal import butter, filtfilt, hilbert
 
 from .gp_freq_bands import FREQUENCY_BANDS
+
+warnings.filterwarnings(
+    "ignore",
+    message=r".*`trapz` is deprecated.*",
+    category=DeprecationWarning,
+)
 
 matplotlib.use("Agg")  # Headless-friendly backend
 import matplotlib.pyplot as plt
@@ -75,7 +82,13 @@ def gp_analysis_pipeline(filtered_data: np.ndarray, lambda_schedule: np.ndarray)
     mi_peak = float(np.max(envelope))
     gradient = np.gradient(envelope)
     transition_sharpness = float(np.max(np.abs(gradient)))
-    hysteresis_area = float(np.trapezoid(np.abs(envelope - envelope.mean()), lam))
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r".*`trapz` is deprecated.*",
+            category=DeprecationWarning,
+        )
+        hysteresis_area = float(np.trapz(np.abs(envelope - envelope.mean()), lam))
 
     return {
         "lambda_star": lambda_star,


### PR DESCRIPTION
## Summary
- switch GP pipeline and experiment integrations to numpy.trapz while suppressing the deprecation warning
- add local warning handling so hysteresis and band power calculations continue returning floats without errors

## Testing
- pytest tests/test_gp_multiband_smoke.py tests/test_phase_map_surrogate.py

------
https://chatgpt.com/codex/tasks/task_e_68dabb797cb8832c9d2d0576f24805c1