### PR TITLE
Fix GP scripts imports for standalone execution

### DIFF
--- a/scripts/gp_ringing_demo.py
+++ b/scripts/gp_ringing_demo.py
@@ -14,7 +14,14 @@ import matplotlib
 import numpy as np
 from scipy.signal import butter, filtfilt, hilbert
 
-from .gp_freq_bands import FREQUENCY_BANDS
+if __package__ in (None, ""):
+    import sys
+    from pathlib import Path
+
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    from scripts.gp_freq_bands import FREQUENCY_BANDS
+else:
+    from .gp_freq_bands import FREQUENCY_BANDS
 
 matplotlib.use("Agg")  # Headless-friendly backend
 import matplotlib.pyplot as plt

--- a/scripts/gp_validation.py
+++ b/scripts/gp_validation.py
@@ -9,8 +9,16 @@ from typing import Dict, Iterable, List, Mapping, Sequence
 import numpy as np
 from scipy.signal import butter, filtfilt
 
-from .gp_freq_bands import FREQUENCY_BANDS
-from .gp_ringing_demo import multi_band_gp_analysis
+if __package__ in (None, ""):
+    import sys
+    from pathlib import Path
+
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    from scripts.gp_freq_bands import FREQUENCY_BANDS
+    from scripts.gp_ringing_demo import multi_band_gp_analysis
+else:
+    from .gp_freq_bands import FREQUENCY_BANDS
+    from .gp_ringing_demo import multi_band_gp_analysis
 
 RESULTS_PATH = os.path.join("results", "gp_demo", "multi_frequency_validation.json")
 


### PR DESCRIPTION
## Summary
- add package-detection guards in the GP demo and validation scripts so they can import shared helpers when run as modules or standalone scripts

## Testing
- python - <<'PY'
import scripts.gp_ringing_demo
import scripts.gp_validation
PY
- python scripts/gp_ringing_demo.py
- python scripts/gp_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68dabba70db4832caf9ba27d8af0a854