### PR TITLE
Fix BH correction handling for unsorted inputs

### DIFF
--- a/scripts/gp_validation.py
+++ b/scripts/gp_validation.py
@@ -86,11 +86,12 @@ def apply_multiple_comparisons_correction(p_values: Sequence[float], method: str
     if method != "fdr_bh":
         raise ValueError("Unsupported correction method")
     order = np.argsort(p_values)
-    ranked = np.empty_like(p_values)
+    sorted_p = p_values[order]
     m = p_values.size
-    for i, idx in enumerate(order, start=1):
-        ranked[idx] = p_values[idx] * m / i
-    adjusted = np.minimum.accumulate(ranked[::-1])[::-1]
+    ranked = sorted_p * m / np.arange(1, m + 1)
+    adjusted_sorted = np.minimum.accumulate(ranked[::-1])[::-1]
+    adjusted = np.empty_like(adjusted_sorted)
+    adjusted[order] = adjusted_sorted
     return np.clip(adjusted, 0.0, 1.0)
 
 

--- a/tests/experiments/test_gp_validation.py
+++ b/tests/experiments/test_gp_validation.py
@@ -1,0 +1,14 @@
+"""Regression tests for GP validation utilities."""
+
+import numpy as np
+
+from scripts.gp_validation import apply_multiple_comparisons_correction
+
+
+def test_apply_multiple_comparisons_correction_unsorted_input() -> None:
+    """Benjamini–Hochberg correction should respect original ordering."""
+
+    p_values = np.array([0.04, 0.001, 0.02])
+    corrected = apply_multiple_comparisons_correction(p_values, method="fdr_bh")
+
+    np.testing.assert_allclose(corrected, np.array([0.04, 0.003, 0.03]))


### PR DESCRIPTION
## Summary
- ensure the Benjamini–Hochberg correction works by operating on sorted p-values and restoring the original order afterward
- add a regression test covering unsorted p-values to validate the new behaviour

## Testing
- pytest tests/experiments/test_gp_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68dabec38f0c832c89fcb2aba268e2e0