### PR TITLE
Add BFS shortest path helpers to local networkx shim

### DIFF
--- a/networkx/__init__.py
+++ b/networkx/__init__.py
@@ -1,7 +1,8 @@
 """A lightweight subset of the :mod:`networkx` API used for testing."""
 from __future__ import annotations
 
-from typing import Dict, Iterable, Iterator, List, Optional, Tuple
+from collections import deque
+from typing import Dict, Iterable, Iterator, List, Mapping, Optional, Tuple
 
 import numpy as np
 
@@ -59,6 +60,9 @@ class Graph:
     def get_edge_data(self, u: object, v: object) -> Optional[Dict[str, object]]:
         return self._adj.get(u, {}).get(v)
 
+    def is_directed(self) -> bool:
+        return False
+
     def adjacency(self) -> Dict[object, Dict[object, Dict[str, object]]]:
         return self._adj
 
@@ -105,3 +109,30 @@ def path_graph(length: int) -> Graph:
             graph.add_edge(prev, idx)
         prev = idx
     return graph
+
+
+def single_source_shortest_path_length(
+    graph: Graph, source: object
+) -> Mapping[object, int]:
+    """Compute shortest path lengths from ``source`` using BFS."""
+
+    if source not in graph:
+        raise KeyError(f"{source!r} is not a node in the graph")
+
+    lengths: Dict[object, int] = {source: 0}
+    queue: deque[object] = deque([source])
+    while queue:
+        u = queue.popleft()
+        for v in graph.neighbors(u):
+            if v in lengths:
+                continue
+            lengths[v] = lengths[u] + 1
+            queue.append(v)
+    return lengths
+
+
+def all_pairs_shortest_path_length(graph: Graph) -> Iterable[Tuple[object, Mapping[object, int]]]:
+    """Yield shortest path lengths for all source nodes in ``graph``."""
+
+    for node in graph.nodes():
+        yield node, single_source_shortest_path_length(graph, node)


### PR DESCRIPTION
## Summary
- extend the vendored lightweight networkx shim with breadth-first search utilities
- provide single-source and all-pairs shortest path length helpers to support curvature computations
- add an `is_directed` predicate so callers can safely query graph orientation

## Testing
- `python -c "from experiments.phase1_prediction import run_phase1_analysis
result = run_phase1_analysis(n_runs=10, seed=42)
print(f'Test passed: {len(result)} results generated')
print(f'Sample result: {result[0]}')"` *(fails: NameError: name 'cat' is not defined raised from existing script contents)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2b65d23c832c8bf972215c6446d4