### PR TITLE
Fix all-pairs distance computation without deprecated API

### DIFF
--- a/tools/ricci.py
+++ b/tools/ricci.py
@@ -30,7 +30,12 @@ def _node_measure(graph: nx.Graph, node: object, alpha: float) -> _Measure:
 
 
 def _all_pairs_distances(graph: nx.Graph) -> Mapping[object, Mapping[object, float]]:
-    return {node: dict(lengths) for node, lengths in nx.all_pairs_shortest_path_length(graph)}
+    """Compute unweighted shortest path distances between all node pairs."""
+
+    return {
+        source: dict(nx.single_source_shortest_path_length(graph, source))
+        for source in graph.nodes()
+    }
 
 
 def _earth_mover_distance(


### PR DESCRIPTION
## Summary
- replace the deprecated/removed NetworkX all-pairs helper with single-source BFS calls
- keep the Ollivier--Ricci utilities compatible with the lightweight NetworkX shim

## Testing
- python -c "from experiments.phase1_prediction import run_phase1_analysis; run_phase1_analysis(n_runs=10, seed=42)" *(fails: NameError: name 'cat' is not defined in experiments/phase1_prediction.py)*

------
https://chatgpt.com/codex/tasks/task_e_68dc54c96494832cb1331ac3717402a2