### PR TITLE
Fix Task 0: Resolve NetworkX integration for forbidden region detection

### DIFF
--- a/docs/experiments/Forbidden_Region_Detector.md
+++ b/docs/experiments/Forbidden_Region_Detector.md
@@ -4,7 +4,7 @@ This sprint delivers a minimal forbidden-region detector on top of a self-contai
 
 - Runs randomized exploration over a 4D grid spanning the parameters $(\lambda, \beta, A)$ and the emergent $\lVert g \rVert$ norm bin.
 - Logs which cells were visited and marks the remainder as candidate forbidden regions.
-- Estimates the largest connected forbidden structure via 2D projections.
+- Estimates the largest connected forbidden structure via a NetworkX lattice graph.
 - Emits a JSON summary for downstream pipelines.
 - Saves lightweight heatmap projections as quick-look PNGs.
 
@@ -24,7 +24,7 @@ python experiments/adversarial_forcing.py
 
 Running the detector writes artifacts to:
 
-- `results/forbidden_v0/forbidden_summary.json`: summary metrics and decision hint.
+- `results/forbidden_v0/forbidden_summary.json`: summary metrics and decision hint, including the size of the largest forbidden connected component.
 - `results/forbidden_v0/visited_4d.npy`: boolean occupancy grid.
 - `figures/forbidden_v0/forbidden_lam_beta.png`: % forbidden per $(\lambda, \beta)$ slice.
 - `figures/forbidden_v0/forbidden_lam_A.png`: % forbidden per $(\lambda, A)$ slice.

--- a/experiments/forbidden_region_detector.py
+++ b/experiments/forbidden_region_detector.py
@@ -1,59 +1,290 @@
 #!/usr/bin/env python3
-import argparse, json, os, time, math, pathlib
-import numpy as np
+"""Forbidden-region detector utilities and CLI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import time
+from typing import Sequence, Tuple
+
 import matplotlib.pyplot as plt
+import networkx as nx
+import numpy as np
+
 
 # --------------------------
 # Toy GP evolve (as in your v0)
 # --------------------------
-def gp_toy_evolve(state, lam, beta, A, steps=200, dt=0.05, rng=None):
-    """
-    Minimal surrogate dynamics:
-    - state: (n,) vector
-    - lam, beta, A: scalars
-    """
+def gp_toy_evolve(
+    state: np.ndarray,
+    lam: float,
+    beta: float,
+    A: float,
+    *,
+    steps: int = 200,
+    dt: float = 0.05,
+    rng: np.random.Generator | None = None,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Integrate the surrogate GP dynamics for ``steps`` iterations."""
+
     if rng is None:
         rng = np.random.default_rng()
     n = state.shape[0]
     # simple laplacian on ring
-    L = -2*np.eye(n)
+    L = -2 * np.eye(n)
     for i in range(n):
-        L[i,(i-1)%n] = 1
-        L[i,(i+1)%n] = 1
+        L[i, (i - 1) % n] = 1
+        L[i, (i + 1) % n] = 1
 
     x = state.copy()
     for _ in range(steps):
         I_meas = np.tanh(x)  # surrogate info flow
-        dx = (I_meas - lam*x - beta*(L@x) - A*(I_meas - np.tanh(x)))  # same as v0 toy
-        x = x + dt*dx + 0.01*rng.standard_normal(size=n)
+        dx = (
+            I_meas
+            - lam * x
+            - beta * (L @ x)
+            - A * (I_meas - np.tanh(x))
+        )  # same as v0 toy
+        x = x + dt * dx + 0.01 * rng.standard_normal(size=n)
     return x, L
 
-def cell_index_4d(vals, mins, maxs, grid):
+
+def cell_index_4d(
+    vals: Sequence[float],
+    mins: Sequence[float],
+    maxs: Sequence[float],
+    grid: Sequence[int],
+) -> Tuple[int, int, int, int]:
+    """Quantise ``vals`` into the 4D grid defined by ``mins``/``maxs``/``grid``."""
+
     idx = []
     for v, lo, hi, n in zip(vals, mins, maxs, grid):
-        vclip = np.clip(v, lo, hi)
+        vclip = float(np.clip(v, lo, hi))
         t = (vclip - lo) / (hi - lo + 1e-12)
         k = int(np.floor(t * n))
-        k = max(0, min(n-1, k))
+        k = max(0, min(n - 1, k))
         idx.append(k)
-    return tuple(idx)
+    return tuple(idx)  # type: ignore[return-value]
 
-def project_pairs(mask4d, axis_i, axis_j):
-    # max-over other dims to show occupied/visited projection
-    M = mask4d
+
+def project_pairs(mask4d: np.ndarray, axis_i: int, axis_j: int) -> np.ndarray:
+    """Project the 4D occupancy mask along two axes."""
+
     axes = tuple(k for k in range(4) if k not in (axis_i, axis_j))
-    proj = M.max(axis=axes)
+    proj = mask4d.max(axis=axes)
     return proj
 
-def ensure_dir(p):
-    pathlib.Path(p).mkdir(parents=True, exist_ok=True)
 
-def main():
+def ensure_dir(path: os.PathLike[str] | str) -> None:
+    """Create ``path`` (and parents) if it does not exist."""
+
+    pathlib.Path(path).mkdir(parents=True, exist_ok=True)
+
+
+def compute_largest_forbidden_component(visited: np.ndarray) -> int:
+    """Return the size of the largest connected forbidden component."""
+
+    grid_shape = tuple(int(s) for s in visited.shape)
+    graph = nx.grid_graph(dim=grid_shape)
+    # Remove nodes corresponding to visited cells so only forbidden nodes remain.
+    to_remove = [node for node in list(graph.nodes()) if visited[node]]
+    graph.remove_nodes_from(to_remove)
+
+    largest = 0
+    for component in nx.connected_components(graph):
+        largest = max(largest, len(component))
+    return largest
+
+
+def _parameter_bounds() -> Tuple[Sequence[float], Sequence[float]]:
+    mins = [0.0, 0.0, 0.0, 0.0]
+    maxs = [2.0, 2.0, 2.0, 5.0]
+    return mins, maxs
+
+
+def run_random_exploration(
+    grid_shape: Sequence[int],
+    *,
+    n_random_runs: int,
+    steps: int,
+    seeds: int,
+    base_seed: int,
+    n: int,
+    dt: float,
+    log_progress: bool = False,
+) -> Tuple[np.ndarray, float]:
+    """Perform random scans of the parameter grid returning the visited mask."""
+
+    visited = np.zeros(tuple(int(g) for g in grid_shape), dtype=bool)
+    mins, maxs = _parameter_bounds()
+    t0 = time.time()
+
+    total_runs = n_random_runs * max(seeds, 1)
+    for s in range(seeds):
+        rng = np.random.default_rng(base_seed + s)
+        for i in range(n_random_runs):
+            if log_progress and (i + 1) % 1000 == 0:
+                print(f"[random] {i + 1}/{total_runs}")
+            lam = rng.uniform(mins[0], maxs[0])
+            beta = rng.uniform(mins[1], maxs[1])
+            A = rng.uniform(mins[2], maxs[2])
+            x0 = rng.standard_normal(n)
+            xT, _ = gp_toy_evolve(x0, lam, beta, A, steps=steps, dt=dt, rng=rng)
+            gnorm = float(np.linalg.norm(xT))
+
+            ijkl = cell_index_4d([lam, beta, A, gnorm], mins, maxs, grid_shape)
+            visited[ijkl] = True
+
+    runtime = time.time() - t0
+    return visited, runtime
+
+
+def build_summary(
+    visited: np.ndarray,
+    grid_shape: Sequence[int],
+    *,
+    n_random_runs: int,
+    seeds: int,
+    n: int,
+    steps: int,
+    runtime: float,
+) -> dict:
+    """Assemble detector summary statistics for downstream consumers."""
+
+    total_cells = int(visited.size)
+    visited_cells = int(visited.sum())
+    forbidden_cells = total_cells - visited_cells
+    forbidden_pct = 100.0 * forbidden_cells / total_cells if total_cells else 0.0
+    largest_component = compute_largest_forbidden_component(visited)
+
+    summary = {
+        "grid_res": int(grid_shape[0]) if grid_shape else 0,
+        "grid_shape": [int(s) for s in grid_shape],
+        "total_cells": total_cells,
+        "visited_cells": visited_cells,
+        "forbidden_cells": forbidden_cells,
+        "forbidden_pct": float(forbidden_pct),
+        # Maintain the legacy key but populate it with the real statistic.
+        "largest_cc_proxy": int(largest_component),
+        "largest_forbidden_component": int(largest_component),
+        "random_runs": int(n_random_runs * max(seeds, 1)),
+        "n": int(n),
+        "steps": int(steps),
+        "runtime_sec": round(runtime, 3),
+        "decision_hint": "ESCALATE" if forbidden_pct > 5 else "TENTATIVE",
+    }
+    return summary
+
+
+def write_detector_outputs(
+    out_dir: os.PathLike[str] | str,
+    visited: np.ndarray,
+    summary: dict,
+    *,
+    generate_figures: bool,
+    update_progress: bool,
+) -> dict:
+    """Persist detector artefacts and return the enriched summary."""
+
+    ensure_dir(out_dir)
+    visited_path = os.path.join(out_dir, "visited_4d.npy")
+    np.save(visited_path, visited)
+
+    summary = dict(summary)
+    summary["visited_path"] = visited_path
+    summary_path = os.path.join(out_dir, "forbidden_summary.json")
+    summary["summary_path"] = summary_path
+    with open(summary_path, "w") as f:
+        json.dump(summary, f, indent=2)
+
+    if generate_figures:
+        ensure_dir("figures/forbidden_vX")  # generic sink
+        figroot = "figures/forbidden_vX"
+
+        labels = ["λ", "β", "A", "||g||"]
+
+        def save_proj(ax_i: int, ax_j: int, name: str) -> None:
+            proj = project_pairs(visited, ax_i, ax_j)  # True = visited
+            plt.figure(figsize=(4, 4))
+            plt.imshow(~proj.T, origin="lower", aspect="auto", cmap="Reds")  # red = forbidden
+            plt.title(f"Forbidden projection: {name}")
+            plt.xlabel(labels[ax_i])
+            plt.ylabel(labels[ax_j])
+            plt.tight_layout()
+            outpng = os.path.join(figroot, f"{name}.png")
+            plt.savefig(outpng, dpi=120)
+            plt.close()
+
+        save_proj(0, 1, "forbidden_lam_beta")
+        save_proj(0, 2, "forbidden_lam_A")
+        save_proj(1, 2, "forbidden_beta_A")
+
+    if update_progress:
+        os.system("python tools/update_progress.py forbidden 100")
+
+    return summary
+
+
+def minimal_forbidden_test(
+    *,
+    grid_res: int = 6,
+    n_random_runs: int = 200,
+    n: int = 8,
+    steps: int = 100,
+    dt: float = 0.05,
+    seed: int = 123,
+    out_dir: str = "results/forbidden_test",
+    generate_figures: bool = False,
+    update_progress: bool = False,
+) -> dict:
+    """Convenience wrapper used by the test-suite to exercise the detector."""
+
+    grid_shape = tuple(int(grid_res) for _ in range(4))
+    visited, runtime = run_random_exploration(
+        grid_shape,
+        n_random_runs=n_random_runs,
+        steps=steps,
+        seeds=1,
+        base_seed=seed,
+        n=n,
+        dt=dt,
+        log_progress=False,
+    )
+    summary = build_summary(
+        visited,
+        grid_shape,
+        n_random_runs=n_random_runs,
+        seeds=1,
+        n=n,
+        steps=steps,
+        runtime=runtime,
+    )
+    return write_detector_outputs(
+        out_dir,
+        visited,
+        summary,
+        generate_figures=generate_figures,
+        update_progress=update_progress,
+    )
+
+
+def main() -> None:
+    """CLI entry point for the forbidden-region detector."""
+
     p = argparse.ArgumentParser(
         description="Forbidden-region minimal detector (now actually respects CLI flags)."
     )
-    p.add_argument("--grid", nargs=4, type=int, metavar=("N1","N2","N3","N4"),
-                   default=[8,8,8,8], help="Grid resolution per dim (λ, β, A, ||g||).")
+    p.add_argument(
+        "--grid",
+        nargs=4,
+        type=int,
+        metavar=("N1", "N2", "N3", "N4"),
+        default=[8, 8, 8, 8],
+        help="Grid resolution per dim (λ, β, A, ||g||).",
+    )
     p.add_argument("--runs", type=int, default=10000, help="Number of random starts.")
     p.add_argument("--steps", type=int, default=200, help="Integration steps per run.")
     p.add_argument("--seeds", type=int, default=1, help="Number of random seeds.")
@@ -63,93 +294,41 @@ def main():
     p.add_argument("--dt", type=float, default=0.05, help="Integrator dt.")
     args = p.parse_args()
 
-    # Parameter box (same ranges as v0)
-    lam_min, lam_max = 0.0, 2.0
-    beta_min, beta_max = 0.0, 2.0
-    A_min,   A_max   = 0.0, 2.0
-    gnorm_min, gnorm_max = 0.0, 5.0
+    grid_shape = tuple(int(g) for g in args.grid)
+    visited, runtime = run_random_exploration(
+        grid_shape,
+        n_random_runs=args.runs,
+        steps=args.steps,
+        seeds=args.seeds,
+        base_seed=args.seed,
+        n=args.n,
+        dt=args.dt,
+        log_progress=True,
+    )
+    summary = build_summary(
+        visited,
+        grid_shape,
+        n_random_runs=args.runs,
+        seeds=args.seeds,
+        n=args.n,
+        steps=args.steps,
+        runtime=runtime,
+    )
+    summary = write_detector_outputs(
+        args.out,
+        visited,
+        summary,
+        generate_figures=True,
+        update_progress=True,
+    )
 
-    Nlam, Nbeta, NA, Ng = args.grid
-    visited = np.zeros((Nlam, Nbeta, NA, Ng), dtype=bool)
-
-    t0 = time.time()
-    total_runs = args.runs * args.seeds
-    for s in range(args.seeds):
-        rng = np.random.default_rng(args.seed + s)
-        for i in range(args.runs):
-            if (i+1) % 1000 == 0:
-                print(f"[random] {i+1}/{args.runs * args.seeds}")
-            lam = rng.uniform(lam_min, lam_max)
-            beta = rng.uniform(beta_min, beta_max)
-            A    = rng.uniform(A_min,   A_max)
-            x0 = rng.standard_normal(args.n)
-            xT, L = gp_toy_evolve(x0, lam, beta, A, steps=args.steps, dt=args.dt, rng=rng)
-            gnorm = float(np.linalg.norm(xT))
-
-            ijkl = cell_index_4d(
-                [lam, beta, A, gnorm],
-                [lam_min, beta_min, A_min, gnorm_min],
-                [lam_max, beta_max, A_max, gnorm_max],
-                [Nlam, Nbeta, NA, Ng]
-            )
-            visited[ijkl] = True
-
-    # Summaries
-    total_cells = visited.size
-    visited_cells = int(visited.sum())
-    forbidden_cells = total_cells - visited_cells
-    forbidden_pct = 100.0 * forbidden_cells / total_cells
-
-    # crude proxy for largest connected component in forbidden set (2D slice heuristic)
-    # (keep simple for now)
-    largest_cc_proxy = int((~visited).astype(int).max())
-
-    ensure_dir(args.out)
-    # Save raw occupancy
-    np.save(os.path.join(args.out, "visited_4d.npy"), visited)
-
-    # Save summary
-    summary = {
-        "grid_res": int(Nlam),    # square grid assumed in 4 dims for brevity of label
-        "total_cells": int(total_cells),
-        "visited_cells": int(visited_cells),
-        "forbidden_cells": int(forbidden_cells),
-        "forbidden_pct": float(forbidden_pct),
-        "largest_cc_proxy": int(largest_cc_proxy),
-        "random_runs": int(args.runs * args.seeds),
-        "n": int(args.n),
-        "steps": int(args.steps),
-        "runtime_sec": round(time.time() - t0, 3),
-        "decision_hint": "ESCALATE" if forbidden_pct > 5 else "TENTATIVE"
-    }
-    with open(os.path.join(args.out, "forbidden_summary.json"), "w") as f:
-        json.dump(summary, f, indent=2)
-    os.system("python tools/update_progress.py forbidden 100")
-
-    # Quick projections (λ–β, λ–A, β–A) with ||g|| maxed out
-    ensure_dir("figures/forbidden_vX")  # generic sink
-    figroot = "figures/forbidden_vX"
-
-    def save_proj(ax_i, ax_j, name):
-        proj = project_pairs(visited, ax_i, ax_j)  # True = visited
-        plt.figure(figsize=(4,4))
-        plt.imshow(~proj.T, origin="lower", aspect="auto", cmap="Reds")  # red = forbidden
-        plt.title(f"Forbidden projection: {name}")
-        plt.xlabel(["λ","β","A","||g||"][ax_i])
-        plt.ylabel(["λ","β","A","||g||"][ax_j])
-        plt.tight_layout()
-        outpng = os.path.join(figroot, f"{name}.png")
-        plt.savefig(outpng, dpi=120)
-        plt.close()
-
-    save_proj(0,1,"forbidden_lam_beta")
-    save_proj(0,2,"forbidden_lam_A")
-    save_proj(1,2,"forbidden_beta_A")
-
-    print(f"[detector] wrote: {args.out}/forbidden_summary.json")
-    print(f"[detector] steps={args.steps}, runs={args.runs}×{args.seeds}, grid={args.grid}")
-    print(f"[detector] forbidden % = {forbidden_pct:.2f}")
+    print(f"[detector] wrote: {summary['summary_path']}")
+    print(
+        f"[detector] steps={args.steps}, runs={args.runs}×{args.seeds}, grid={list(grid_shape)}"
+    )
+    print(f"[detector] forbidden % = {summary['forbidden_pct']:.2f}")
     print("[detector] DONE")
+
 
 if __name__ == "__main__":
     main()

--- a/tests/experiments/test_forbidden_minimal.py
+++ b/tests/experiments/test_forbidden_minimal.py
@@ -1,10 +1,25 @@
 import os
 
-from experiments.forbidden_region_detector import minimal_forbidden_test
+import numpy as np
+from experiments.forbidden_region_detector import (
+    compute_largest_forbidden_component,
+    minimal_forbidden_test,
+)
 
 
 def test_minimal_forbidden_runs(tmp_path):
     out = tmp_path / "res"
     summ = minimal_forbidden_test(grid_res=4, n_random_runs=50, n=4, steps=50, out_dir=str(out))
     assert "forbidden_pct" in summ
+    assert "largest_forbidden_component" in summ
     assert os.path.exists(out / "forbidden_summary.json")
+
+
+def test_largest_component_uses_networkx():
+    visited = np.ones((2, 2, 2, 2), dtype=bool)
+    visited[(0, 0, 0, 0)] = False
+    visited[(0, 0, 0, 1)] = False
+    visited[(1, 1, 1, 1)] = False
+
+    largest = compute_largest_forbidden_component(visited)
+    assert largest == 2


### PR DESCRIPTION
## Summary
- extend the bundled NetworkX shim to support multi-dimensional grid graphs and connected component queries
- refactor the forbidden-region detector into reusable helpers that compute the largest forbidden component with NetworkX and expose a minimal test harness
- update documentation and tests to validate the NetworkX integration for forbidden-region detection

## Testing
- pytest tests/experiments/test_forbidden_minimal.py -q

------
https://chatgpt.com/codex/tasks/task_e_68de5be43e74832ca9460ab673aa1cda