### PR TITLE
Remove smoke flag from GP ringing demo workflow

### DIFF
--- a/.github/workflows/gp-demo.yml
+++ b/.github/workflows/gp-demo.yml
@@ -34,7 +34,7 @@ jobs:
           RG_CI: '1'
         run: |
           mkdir -p figures
-          python experiments/gp_ringing_demo.py --smoke --out figures/gp_ringing_smoke.png || true
+          python experiments/gp_ringing_demo.py --out figures/gp_ringing_smoke.png || true
 
       - name: Upload figures (artifacts)
         if: always()


### PR DESCRIPTION
## Summary
- remove the `--smoke` flag from the GP ringing demo workflow step so the full demo runs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e529695b08832c86abf3d4328d3839